### PR TITLE
[FEAT] SpringSecurity+JWT+OAuth2 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
@@ -2,8 +2,11 @@ package site.beilsang.beilsang_server_v2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@EnableJpaAuditing
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class BeilsangServerV2Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
@@ -6,7 +6,8 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+//@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class BeilsangServerV2Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-//@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class BeilsangServerV2Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
@@ -1,0 +1,20 @@
+package site.beilsang.beilsang_server_v2.domain.member.dto;
+
+import org.springframework.stereotype.Component;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.global.enums.Provider;
+import site.beilsang.beilsang_server_v2.global.enums.Role;
+import site.beilsang.beilsang_server_v2.global.oauth.dto.OAuth2UserInfo;
+
+@Component
+public class MemberAssembler {
+
+    public Member toEntity(Provider provider, OAuth2UserInfo oAuth2UserInfo) {
+        return Member.builder()
+                .provider(provider)
+                .socialId(oAuth2UserInfo.getId())
+                .email(oAuth2UserInfo.getEmail())
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
@@ -1,11 +1,13 @@
 package site.beilsang.beilsang_server_v2.domain.member.dto;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.global.enums.Provider;
 import site.beilsang.beilsang_server_v2.global.enums.Role;
 import site.beilsang.beilsang_server_v2.global.oauth.dto.OAuth2UserInfo;
 
+@Slf4j
 @Component
 public class MemberAssembler {
 
@@ -15,6 +17,14 @@ public class MemberAssembler {
                 .socialId(oAuth2UserInfo.getId())
                 .email(oAuth2UserInfo.getEmail())
                 .role(Role.GUEST)
+                .build();
+    }
+
+    public static MemberLoginResDTO toMemberLoginResDTO(String accessToken, String refreshToken, Role role) {
+        return MemberLoginResDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .role(role)
                 .build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberLoginResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberLoginResDTO.java
@@ -1,0 +1,13 @@
+package site.beilsang.beilsang_server_v2.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import site.beilsang.beilsang_server_v2.global.enums.Role;
+
+@Getter
+@Builder
+public class MemberLoginResDTO {
+    private String accessToken;
+    private String refreshToken;
+    private Role role;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
@@ -41,7 +41,6 @@ public class ChallengeMember extends BaseEntity {
     @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
-
     @OneToMany(mappedBy = "challengeMember", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Feed> feed = new ArrayList<>();
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
@@ -1,7 +1,10 @@
 package site.beilsang.beilsang_server_v2.domain.member.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import site.beilsang.beilsang_server_v2.domain.feed.entity.FeedLike;
 import site.beilsang.beilsang_server_v2.domain.like.entity.ChallengeLike;
 import site.beilsang.beilsang_server_v2.domain.point.entity.PointLog;
@@ -16,6 +19,9 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
@@ -30,6 +30,7 @@ public class Member {
 
     private String email;
 
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     @Enumerated(EnumType.STRING)
@@ -77,4 +78,8 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeLike> challengeLikes = new ArrayList<>();
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package site.beilsang.beilsang_server_v2.domain.member.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findBySocialId(String socialId);
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findBySocialId(String socialId);
+    Optional<Member> findBySocialIdAndEmail(String socialId, String email);
 
     Optional<Member> findBySocialIdAndProvider(String socialId, Provider provider);
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/MemberRepository.java
@@ -4,6 +4,7 @@ package site.beilsang.beilsang_server_v2.domain.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.global.enums.Provider;
 
 import java.util.Optional;
 
@@ -11,5 +12,9 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialId(String socialId);
+
+    Optional<Member> findBySocialIdAndProvider(String socialId, Provider provider);
+
+
 
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/controller/OAuthController.java
@@ -1,0 +1,10 @@
+package site.beilsang.beilsang_server_v2.domain.oauth.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/oauth")
+public class OAuthController {
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package site.beilsang.beilsang_server_v2.global.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.info("[CustomAccessDeniedHandler] :: {}", accessDeniedException.getMessage());
+        log.info("[CustomAccessDeniedHandler] :: {}", request.getRequestURL());
+        log.info("[CustomAccessDeniedHandler] :: 토근 정보가 만료되었거나 존재하지 않음");
+
+        //TODO - 에러 핸들링
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
@@ -1,0 +1,27 @@
+package site.beilsang.beilsang_server_v2.global.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+    // 인증되지 않은 사용자가 접근 시 동작
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.info("[CustomAuthenticationEntryPointHandler] :: {}", authException.getMessage());
+        log.info("[CustomAuthenticationEntryPointHandler] :: {}", request.getRequestURL());
+        log.info("[CustomAuthenticationEntryPointHandler] :: 토근 정보가 만료되었거나 존재하지 않음");
+
+        //TODO
+
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
@@ -22,9 +22,9 @@ public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
     //TODO
-//    private final CustomAuthenticationEntryPointHandler customAuthenticationEntryPointHandler;
-//
-//    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPointHandler customAuthenticationEntryPointHandler;
+
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     // 비밀번호 암/복호화를 위한 클래스
     @Bean
@@ -65,15 +65,12 @@ public class SecurityConfig {
         http.sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        //TODO
-/*
         //exception handler
         http.exceptionHandling(conf -> conf
                 // 인증 예외 처리
                 .authenticationEntryPoint(customAuthenticationEntryPointHandler)
                 // 인가 예외 처리
                 .accessDeniedHandler(customAccessDeniedHandler));
-*/
         return http.build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -47,6 +46,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
         MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspector);
+
         // white list
         MvcRequestMatcher[] permitWhiteList = {
                 mvc.pattern("/oauth/**"),
@@ -62,10 +62,10 @@ public class SecurityConfig {
         http.oauth2Login(oauth -> oauth
                 .userInfoEndpoint(userInfo -> userInfo
                         .userService(customOAuth2UserService))
-                .redirectionEndpoint(redirection -> redirection
+                .redirectionEndpoint(redirection -> redirection // 기본 리다이렉션 경로 변경
                         .baseUri("/oauth/redirect/*"))
-                .successHandler(oAuth2LoginSuccessHandler)
-                .failureHandler(oAuth2LoginFailureHandler) //oauth2 로그인 과정 인증 실패
+                .successHandler(oAuth2LoginSuccessHandler) // oauth2 로그인 과정 인증
+                .failureHandler(oAuth2LoginFailureHandler) // oauth2 로그인 과정 인증 실패
         );
 
         // jwt 방식 사용 -> 아래의 4개 미사용 설정

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package site.beilsang.beilsang_server_v2.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+import site.beilsang.beilsang_server_v2.global.jwt.JwtAuthFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    //TODO
+//    private final CustomAuthenticationEntryPointHandler customAuthenticationEntryPointHandler;
+//
+//    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    // 비밀번호 암/복호화를 위한 클래스
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    MvcRequestMatcher.Builder mvc(HandlerMappingIntrospector introspector) {
+        return new MvcRequestMatcher.Builder(introspector);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
+        MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspector);
+
+        // 토큰 검증 filter
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // white list
+        MvcRequestMatcher[] permitWhiteList = {
+                mvc.pattern("/login"),
+                mvc.pattern("/register"),
+                mvc.pattern("/token-refresh"),
+        };
+
+        // http request 인증 설정
+        http.authorizeHttpRequests(autorize -> autorize
+                .requestMatchers(permitWhiteList).permitAll()
+                .anyRequest().authenticated()
+        );
+
+        // jwt 방식 사용 -> 아래의 4개 미사용 설정
+        // form login, logout, csrf, session diabled
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.logout(AbstractHttpConfigurer::disable);
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        //TODO
+/*
+        //exception handler
+        http.exceptionHandling(conf -> conf
+                // 인증 예외 처리
+                .authenticationEntryPoint(customAuthenticationEntryPointHandler)
+                // 인가 예외 처리
+                .accessDeniedHandler(customAccessDeniedHandler));
+*/
+        return http.build();
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/Provider.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/Provider.java
@@ -1,5 +1,21 @@
 package site.beilsang.beilsang_server_v2.global.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
 public enum Provider {
-    KAKAO, APPLE
+    KAKAO("kakao"), APPLE("naver");
+
+    private final String provider;
+    public static Provider getByName(String name){
+        //TODO
+        return Arrays.stream(Provider.values())
+                .filter(provider -> provider.getProvider().equals(name))
+                .findAny().orElseThrow(() -> new RuntimeException());
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/Role.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/Role.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum Role {
+
+    GUEST("GUEST"),
     USER("USER"),
     ADMIN("USER");
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/Role.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/Role.java
@@ -1,8 +1,10 @@
 package site.beilsang.beilsang_server_v2.global.enums;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public enum Role {
     USER("USER"),
     ADMIN("USER");

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -32,11 +32,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         // access token이 존재하지 않거나 토큰이 유효하지 않으면 401 코드 반환
         if (!jwtTokenProvider.validateToken(token) || !StringUtils.hasText(token)) {
-            //TODO - 아래처럼 sendError하면 토큰이 필요 없는 도메인에서 접근 안됨
-            logger.info("토큰 없음");
+
 //            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
             //토큰이 없을 경우
-            doFilter(request,response,filterChain);
+            doFilter(request, response, filterChain);
             return;
         }
         setSecurityContextHolder(token);

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -1,0 +1,5 @@
+package site.beilsang.beilsang_server_v2.global.jwt;
+
+public class JwtAuthFilter {
+    //TODO
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -1,5 +1,86 @@
 package site.beilsang.beilsang_server_v2.global.jwt;
 
-public class JwtAuthFilter {
-    //TODO
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
+import site.beilsang.beilsang_server_v2.global.enums.Role;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // HTTP 요청 헤더에서 access token을 추출
+        String token = extractToken(request);
+
+        // access token이 존재하지 않거나 토큰이 유효하지 않으면 401 코드 반환
+        if (!jwtTokenProvider.validateToken(token) || !StringUtils.hasText(token)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+            return;
+        }
+        setSecurityContextHolder(token);
+        filterChain.doFilter(request, response);
+    }
+
+
+    /**
+     * Header에서 token 추출
+     *
+     * @param request
+     * @return
+     */
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 토큰 속 정보를 바탕으로 유저를 SecurityContextHolder에 저장
+     *
+     * @param token
+     */
+    private void setSecurityContextHolder(String token) {
+        String socialId = jwtTokenProvider.getSocialId(token);
+        //TODO
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new RuntimeException());
+
+        // 인증 토큰을 받아 SecurityContext에 저장
+        SecurityContextHolder.getContext().setAuthentication(getUserAuth(member));
+    }
+
+    /**
+     * 멤버 정보를 바탕으로 인증 토큰 생성
+     *
+     * @param member
+     * @return UsernamePasswordAuthenticationToken
+     */
+    private UsernamePasswordAuthenticationToken getUserAuth(Member member) {
+        return new UsernamePasswordAuthenticationToken(
+                member.getId(),
+                member.getSocialId(),
+                Collections.singleton(new SimpleGrantedAuthority(Role.USER.getRole()))
+        );
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -30,15 +31,24 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // HTTP 요청 헤더에서 access token을 추출
         String token = extractToken(request);
 
+        logger.info("1번-----------------");
         // access token이 존재하지 않거나 토큰이 유효하지 않으면 401 코드 반환
         if (!jwtTokenProvider.validateToken(token) || !StringUtils.hasText(token)) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+            //TODO - 아래처럼 sendError하면 토큰이 필요 없는 도메인에서 접근 안됨
+//            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+            //토큰이 없을 경우
+            doFilter(request,response,filterChain);
             return;
         }
         setSecurityContextHolder(token);
         filterChain.doFilter(request, response);
     }
 
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getServletPath();
+        return path.equals("/form") || path.equals("/favicon.ico") || path.equals("/oauth/**");
+    }
 
     /**
      * Header에서 token 추출

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,112 @@
+package site.beilsang.beilsang_server_v2.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
+
+    @Value("${jwt.secret-key}")
+    private String secretKey; // jwt 시크릿 키
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    /**
+     * access token 생성
+     *
+     * @param socialId
+     * @return accessToken
+     */
+    public String createAccessToken(String socialId) {
+        return createToken(socialId, ACCESS_TOKEN_EXPIRE_TIME);
+    }
+
+    /**
+     * refresh token 생성
+     *
+     * @return refresh token
+     */
+    public String createRefreshToken() {
+        byte[] array = new byte[7];
+        new Random().nextBytes(array);
+        String generatedString = new String(array, StandardCharsets.UTF_8);
+        return createToken(generatedString, REFRESH_TOKEN_EXPIRE_TIME);
+    }
+
+
+    /**
+     * 만료 기한 별 token 생성
+     *
+     * @param socialId
+     * @param expireTime
+     */
+    private String createToken(String socialId, long expireTime) {
+        Claims claims = Jwts.claims().setSubject(socialId);
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + expireTime);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 토큰 유효성 검사
+     *
+     * @param token
+     */
+    public Boolean validateToken(String token) {
+        try {
+            Jws<Claims> claimsJws = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    /**
+     * claim에서 socialId 추출
+     *
+     * @param token
+     */
+    public String getSocialId(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        } catch (JwtException e) {
+            //TODO
+//            throw new ErrorHandler(ErrorStatus.UNAUTHORIZED);
+            throw new RuntimeException();
+        }
+    }
+
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtTokenProvider.java
@@ -108,7 +108,7 @@ public class JwtTokenProvider {
     /**
      * 토큰에서 Claim을 통해 원하는 값 추출
      *
-     * @param token accessToken
+     * @param token    accessToken
      * @param claimKey Claim에서 추출하려는 값
      * @return 값
      */

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CusotmOAuth2User.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CusotmOAuth2User.java
@@ -1,0 +1,28 @@
+package site.beilsang.beilsang_server_v2.global.oauth;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import site.beilsang.beilsang_server_v2.global.enums.Role;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CusotmOAuth2User extends DefaultOAuth2User {
+    // Set<GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey
+    // 위 3개 외에 아래 필드를 추가로 가진다
+    private final String socialId;
+    private final String email; //email은 JWT Token을 발급하기 위한 용도
+    private final Role role;
+
+    public CusotmOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes, String nameAttributeKey,
+                            String socialId,
+                            String email, Role role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.socialId = socialId;
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2User.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2User.java
@@ -9,14 +9,14 @@ import java.util.Collection;
 import java.util.Map;
 
 @Getter
-public class CusotmOAuth2User extends DefaultOAuth2User {
+public class CustomOAuth2User extends DefaultOAuth2User {
     // Set<GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey
     // 위 3개 외에 아래 필드를 추가로 가진다
     private final String socialId;
-    private final String email; //email은 JWT Token을 발급하기 위한 용도
+    private final String email;
     private final Role role;
 
-    public CusotmOAuth2User(Collection<? extends GrantedAuthority> authorities,
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
                             Map<String, Object> attributes, String nameAttributeKey,
                             String socialId,
                             String email, Role role) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2User.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2User.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
+
     // Set<GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey
     // 위 3개 외에 아래 필드를 추가로 가진다
     private final String socialId;

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,81 @@
+package site.beilsang.beilsang_server_v2.global.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import site.beilsang.beilsang_server_v2.domain.member.dto.MemberAssembler;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
+import site.beilsang.beilsang_server_v2.global.enums.Provider;
+import site.beilsang.beilsang_server_v2.global.oauth.dto.OAuthAttributes;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    // 유저 정보를 가져와 회원 정보가 없다면 저장
+
+    private final MemberRepository memberRepository;
+    private final MemberAssembler memberAssembler;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - 로그인 완료, OAuth2 사용자 정보 단계");
+
+        // 로그인 유저 정보 가져옴
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> service = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = service.loadUser(userRequest);
+        log.info("getAttributes: {}", oAuth2User.getAttributes());
+
+        // OAuth2 서비스 id (google, kakao, naver)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Provider provider = Provider.getByName(registrationId);
+        log.info("provider: {}", provider);
+
+        String userNameAttributeName = userRequest.getClientRegistration() // OAuth2 로그인 시 키(PK)가 되는 값
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
+
+        // 소셜 종류에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
+        OAuthAttributes oAuthAttributes = OAuthAttributes.of(provider, userNameAttributeName, attributes);
+        Member member = getMember(oAuthAttributes, provider);
+
+        return new CusotmOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getRole())),
+                attributes,
+                oAuthAttributes.getNameAttributesKey(),
+                oAuthAttributes.getOAuth2UserInfo().getEmail(),
+                member.getEmail(),
+                member.getRole()
+        );
+    }
+
+    /**
+     * SocialType과 attributes에 들어있는 소셜 로그인의 식별값 id를 통해 회원을 찾아 반환하는 메소드
+     * 만약 찾은 회원이 있다면, 그대로 반환하고 없다면 save()를 호출하여 회원을 저장한다.
+     */
+    private Member getMember(OAuthAttributes attributes, Provider provider) {
+        Optional<Member> member = memberRepository.findBySocialIdAndProvider(
+                attributes.getOAuth2UserInfo().getId(), provider);
+
+        if (member.isEmpty()) {
+            log.info("존재하지 않는 유저, 추가하여 return");
+            Member newMember = memberAssembler.toEntity(provider, attributes.getOAuth2UserInfo());
+            return memberRepository.save(newMember);
+        } else {
+            log.info("이미 존재하는 user, findUser return");
+            return member.get();
+        }
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
@@ -35,7 +35,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // 로그인 유저 정보 가져옴
         OAuth2UserService<OAuth2UserRequest, OAuth2User> service = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = service.loadUser(userRequest);
-        log.info("getAttributes: {}", oAuth2User.getAttributes());
 
         // OAuth2 서비스 id (google, kakao, naver)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
@@ -40,7 +40,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // OAuth2 서비스 id (google, kakao, naver)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         Provider provider = Provider.getByName(registrationId);
-        log.info("provider: {}", provider);
 
         String userNameAttributeName = userRequest.getClientRegistration() // OAuth2 로그인 시 키(PK)가 되는 값
                 .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
@@ -51,11 +50,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes oAuthAttributes = OAuthAttributes.of(provider, userNameAttributeName, attributes);
         Member member = getMember(oAuthAttributes, provider);
 
-        return new CusotmOAuth2User(
+        return new CustomOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(member.getRole().getRole())),
                 attributes,
                 oAuthAttributes.getNameAttributesKey(),
-                oAuthAttributes.getOAuth2UserInfo().getEmail(),
+                member.getSocialId(),
                 member.getEmail(),
                 member.getRole()
         );

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/KakaoUserInfo.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/KakaoUserInfo.java
@@ -1,9 +1,11 @@
 package site.beilsang.beilsang_server_v2.global.oauth.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 
+@Slf4j
 public class KakaoUserInfo extends OAuth2UserInfo {
 
     public KakaoUserInfo(Map<String, Object> attributes) {
@@ -12,26 +14,15 @@ public class KakaoUserInfo extends OAuth2UserInfo {
 
     @Override
     public String getId() {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-
-        if (response == null) {
-            return null;
-        }
-        // id : 네이버에서 지정한 동일인 식별 정보 이름
-        return (String) response.get("id");
+        Long socialId = (Long) attributes.get("id");
+        //카카오는 id를 Long형태로 전달
+        return String.valueOf(socialId);
     }
     public String getEmail(){
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
         if (response == null) {
             return null;
         }
         return (String) response.get("email");
-    }
-    public String getUserName(){
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-        if (response == null) {
-            return null;
-        }
-        return (String) response.get("name");
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/KakaoUserInfo.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/KakaoUserInfo.java
@@ -1,6 +1,5 @@
 package site.beilsang.beilsang_server_v2.global.oauth.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
@@ -18,7 +17,8 @@ public class KakaoUserInfo extends OAuth2UserInfo {
         //카카오는 id를 Long형태로 전달
         return String.valueOf(socialId);
     }
-    public String getEmail(){
+
+    public String getEmail() {
         Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
         if (response == null) {
             return null;

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/KakaoUserInfo.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/KakaoUserInfo.java
@@ -1,0 +1,37 @@
+package site.beilsang.beilsang_server_v2.global.oauth.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+public class KakaoUserInfo extends OAuth2UserInfo {
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+        // id : 네이버에서 지정한 동일인 식별 정보 이름
+        return (String) response.get("id");
+    }
+    public String getEmail(){
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("email");
+    }
+    public String getUserName(){
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("name");
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuth2UserInfo.java
@@ -20,5 +20,4 @@ public abstract class OAuth2UserInfo {
     public abstract String getId();
 
     public abstract String getEmail();
-
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuth2UserInfo.java
@@ -1,0 +1,24 @@
+package site.beilsang.beilsang_server_v2.global.oauth.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public abstract class OAuth2UserInfo {
+    //소셜 타입별 로그인 유저 정보
+
+    protected Map<String, Object> attributes;
+
+    /**
+     * 서비스에 사용할 유저 정보들을 가져오는 메소드
+     *
+     * @return
+     */
+    // 동일인 식별 정보를 가져옴(아이디마다 고유하게 발급되는 값)
+    // 네이버, 카카오 = id, 구글 = sub
+    public abstract String getId();
+
+    public abstract String getEmail();
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuthAttributes.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuthAttributes.java
@@ -28,9 +28,6 @@ public class OAuthAttributes {
         if (provider.equals(Provider.KAKAO)) {
             return new KakaoUserInfo(attributes);
         }
-
         return null;
     }
-
-
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuthAttributes.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/dto/OAuthAttributes.java
@@ -1,0 +1,36 @@
+package site.beilsang.beilsang_server_v2.global.oauth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import site.beilsang.beilsang_server_v2.global.enums.Provider;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class OAuthAttributes {
+    /**
+     * 회원 정보를 담는 DTO
+     * 소셜 타입 별로 받는 데이터를 분기 처리한다
+     */
+
+    private String nameAttributesKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private OAuth2UserInfo oAuth2UserInfo; // 소셜 타입별 로그인 유저 정보
+
+    public static OAuthAttributes of(Provider provider, String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributesKey(userNameAttributeName)
+                .oAuth2UserInfo(getOAuth2UserInfoByProvider(provider, attributes))
+                .build();
+    }
+
+    private static OAuth2UserInfo getOAuth2UserInfoByProvider(Provider provider, Map<String, Object> attributes) {
+        if (provider.equals(Provider.KAKAO)) {
+            return new KakaoUserInfo(attributes);
+        }
+
+        return null;
+    }
+
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,19 @@
+package site.beilsang.beilsang_server_v2.global.oauth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜로그인 실패");
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,36 @@
+package site.beilsang.beilsang_server_v2.global.oauth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import site.beilsang.beilsang_server_v2.global.enums.Role;
+import site.beilsang.beilsang_server_v2.global.jwt.JwtTokenProvider;
+import site.beilsang.beilsang_server_v2.global.oauth.CustomOAuth2User;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2LoginSuccessHandler 로그인 성공");
+
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+            jwtTokenProvider.sendToken(response, oAuth2User);
+
+        } catch (Exception e) {
+
+        }
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import site.beilsang.beilsang_server_v2.global.enums.Role;
 import site.beilsang.beilsang_server_v2.global.jwt.JwtTokenProvider;
 import site.beilsang.beilsang_server_v2.global.oauth.CustomOAuth2User;
 


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- closed #2 

## 🍬 기능 설명
- 기존 사용하지 않았던 OAuth2를 적용하여 구현
- SecurityConfig로 스프링 시큐리티 제어
- 로그인 성공 시 CustomOAuth2UserService로 넘어가 사용자 정보 가져옴
- 토큰을 이용해 사이트 접근 시 JwtAuthFilter를 이용해 토큰 검증

## 🤔 코드 리뷰에서 집중적으로 볼 내용
<!-- 코드를 작성하면서 헷갈렸던 부분을 캡처/복사해서 넣자 -->
- config와 jwt, oauth 이렇게 세 패키지로 나눠서 설정해놓음. 다 같은 로그인 기능을 돕는 것들이라 묶는게 좋을 지 지금처럼 나눌지 고민중...🤔🤔
- 리다이렉트를 일단 아래와 같이 설정했는데, 로그인 전용 컨트롤러를 없애놓은지라 경로를 어떻게 하면 좋을 지 이야기하고자 함.
``` 
http.oauth2Login(oauth -> oauth
                .redirectionEndpoint(redirection -> redirection // 기본 리다이렉션 경로 변경
                        .baseUri("/oauth/redirect/*"))
```
- 엔티티 별로 Assembler를 이용해서 Entity와 DTO를 build를 모아둠. 

## ⭐ 기타 사항
<!-- 개발할 때 참고했던 레퍼런스나 공유하면 좋을 것들을 나눠보아요 -->
### 전달 사항
- 토큰 재생성은 아직 개발하지 않음, 애플/카카오 로그인 구현 후 진행 예정
- yaml 파일 또한 첨부 x, 개발 진행 예정 시 따로 연락 바람! 전달해드리겠음
- 각 함수들에 대한 내용은 주석을 통해 설명해둠


### 레퍼런스
1. Spring Security & Jwt 개발 참고  [[Spring Security] Spring Security (JWT, Access Token, Refresh Token) - Spring Security 6.1 이후
](https://jangjjolkit.tistory.com/72)
 2.  OAuth2 참고 [[Spring Security] OAuth2.0 + JWT 로그인 (ver. SpringBoot 3.2.2)](https://velog.io/@hj_/Spring-Security-OAuth2.0-JWT-%EB%A1%9C%EA%B7%B8%EC%9D%B8-ver.-SpringBoot-3.2.2#security-config-%EC%84%A4%EC%A0%95)