### PR TITLE
[FEAT] S3 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,16 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//jwt
+	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	//oauth2
+	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// AWS S3
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,12 +24,10 @@ public class ChallengeController {
     public BaseResponse<ChallengeResDTO> createChallenge(
             Authentication authentication,
             @RequestPart("data") CreateChallengeReqDTO createChallengeReqDTO,
-            @RequestPart("mainImage") MultipartFile mainImage,
-            @RequestPart("certImage") MultipartFile certImage
-    ) {
+            @RequestPart("infoImages") List<MultipartFile> infoImages,
+            @RequestPart("certImages") List<MultipartFile> certImages) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(
-                challengeService.createChallenge(memberId, createChallengeReqDTO, mainImage, certImage)
-        );
+                challengeService.createChallenge(memberId, createChallengeReqDTO, infoImages, certImages));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -25,7 +25,6 @@ public class ChallengeAssembler {
                 .certImageUrl(certImageUrl)
                 .details(request.getDetails())
                 .period(request.getPeriod())
-                .category(request.getCategory())
                 .totalGoalDay(request.getTotalGoalDay())
                 .attendeeCount(1)
                 .countLikes(0)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.dto;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
@@ -10,19 +11,13 @@ import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 @Component
 public class ChallengeAssembler {
 
-    public static Challenge toEntity(
-            CreateChallengeReqDTO request,
-            String mainImageUrl,
-            String certImageUrl
-    ) {
+    public static Challenge toEntity(CreateChallengeReqDTO request) {
         return Challenge.builder()
                 .category(request.getCategory())
                 .title(request.getTitle())
                 .startDate(request.getStartDate())
                 .finishDate(request.getStartDate().plusDays(request.getPeriod().getDays() - 1))
                 .joinPoint(request.getJoinPoint())
-                .mainImageUrl(mainImageUrl)
-                .certImageUrl(certImageUrl)
                 .details(request.getDetails())
                 .period(request.getPeriod())
                 .totalGoalDay(request.getTotalGoalDay())
@@ -33,6 +28,18 @@ public class ChallengeAssembler {
     }
 
     public static ChallengeResDTO toChallengeResDTO(Challenge challenge) {
+        // 정보 이미지 URL 리스트 생성
+        List<String> infoImageUrls = challenge.getInfoImages().stream()
+                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                .map(image -> image.getImageUrl())
+                .toList();
+
+        // 인증 이미지 URL 리스트 생성
+        List<String> certImageUrls = challenge.getCertImages().stream()
+                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                .map(image -> image.getImageUrl())
+                .toList();
+
         return ChallengeResDTO.builder()
                 .challengeId(challenge.getId())
                 .category(challenge.getCategory())
@@ -40,8 +47,8 @@ public class ChallengeAssembler {
                 .startDate(challenge.getStartDate())
                 .finishDate(challenge.getFinishDate())
                 .joinPoint(challenge.getJoinPoint())
-                .mainImageUrl(challenge.getMainImageUrl())
-                .certImageUrl(challenge.getCertImageUrl())
+                .infoImageUrls(infoImageUrls)
+                .certImageUrls(certImageUrls)
                 .details(challenge.getDetails())
                 .period(challenge.getPeriod())
                 .totalGoalDay(challenge.getTotalGoalDay())

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeResDTO.java
@@ -3,10 +3,12 @@ package site.beilsang.beilsang_server_v2.domain.challenge.dto.res;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
+import lombok.Getter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengePeriod;
 
 @Builder
+@Getter
 public class ChallengeResDTO {
     private Long challengeId;
     private Category category;
@@ -14,8 +16,8 @@ public class ChallengeResDTO {
     private LocalDate startDate;
     private LocalDate finishDate;
     private Integer joinPoint;
-    private String mainImageUrl;
-    private String certImageUrl;
+    private List<String> infoImageUrls;
+    private List<String> certImageUrls;
     private String details;
     private List<String> challengeNotes;
     private ChallengePeriod period;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -38,11 +38,13 @@ public class Challenge extends BaseEntity {
 
     private Integer joinPoint;
 
-    private String mainImageUrl;
-
-    private String certImageUrl;
-
     private String details;
+
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChallengeInfoImage> infoImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChallengeCertImage> certImages = new ArrayList<>();
 
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeNote> challengeNotes = new ArrayList<>();

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/ChallengeCertImage.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/ChallengeCertImage.java
@@ -1,0 +1,31 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeCertImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_cert_image_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Integer imageOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/ChallengeInfoImage.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/ChallengeInfoImage.java
@@ -1,0 +1,31 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeInfoImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_info_image_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Integer imageOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeCertImageRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeCertImageRepository.java
@@ -1,0 +1,9 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeCertImage;
+
+@Repository
+public interface ChallengeCertImageRepository extends JpaRepository<ChallengeCertImage, Long> {
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeInfoImageRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeInfoImageRepository.java
@@ -1,0 +1,9 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeInfoImage;
+
+@Repository
+public interface ChallengeInfoImageRepository extends JpaRepository<ChallengeInfoImage, Long> {
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -1,10 +1,12 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.service;
 
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 
 public interface ChallengeService {
 
-    ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO, MultipartFile mainImage, MultipartFile certImage);
+    ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
+            List<MultipartFile> infoImages, List<MultipartFile> certImages);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -18,11 +18,13 @@ import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMember
 import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
 import site.beilsang.beilsang_server_v2.domain.point.entity.PointLog;
 import site.beilsang.beilsang_server_v2.domain.point.repository.PointLogRepository;
+import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
+import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +36,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final ChallengeMemberRepository challengeMemberRepository;
     private final ChallengeNoteRepository challengeNoteRepository;
     private final PointLogRepository pointLogRepository;
+    private final S3Service s3Service;
 
     @Override
     public ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
@@ -56,8 +59,8 @@ public class ChallengeServiceImpl implements ChallengeService {
         member.subPoint(joinPoint); // 포인트 차감
 
         // S3 이용 챌린지 이미지 저장 로직
-        String mainImageUrl = null;
-        String certImageUrl = null;
+        String mainImageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_MAIN, mainImage);
+        String certImageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_CERT, certImage);
 
         // 챌린지 생성
         Challenge challenge = challengeRepository.save(

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -41,9 +41,26 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     public ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
                                            MultipartFile mainImage, MultipartFile certImage) {
+        // 이미지 파일 검증
+        if (mainImage == null || mainImage.isEmpty()) {
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
+        }
+        if (certImage == null || certImage.isEmpty()) {
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
+        }
+
+        // 목표 일수가 전체 기간을 초과하지 않는지 검증
+        if (createChallengeReqDTO.getTotalGoalDay() > createChallengeReqDTO.getPeriod().getDays()) {
+            throw new BaseException(BaseResponseCode.INVALID_CHALLENGE_PERIOD);
+        }
+
+        // 시작 날짜가 오늘 이후인지 검증 (오늘은 허용)
+        if (createChallengeReqDTO.getStartDate().isBefore(LocalDate.now())) {
+            throw new BaseException(BaseResponseCode.INVALID_START_DATE);
+        }
+
         Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER)
-        );
+                () -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
 
         // 멤버 포인트 부족 시 예외 처리
         int joinPoint = createChallengeReqDTO.getJoinPoint();
@@ -64,8 +81,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         // 챌린지 생성
         Challenge challenge = challengeRepository.save(
-                ChallengeAssembler.toEntity(createChallengeReqDTO, mainImageUrl, certImageUrl)
-        );
+                ChallengeAssembler.toEntity(createChallengeReqDTO, mainImageUrl, certImageUrl));
 
         // ChallengeNote 생성
         challengeNoteRepository.saveAll(createChallengeReqDTO.getNotes().stream()

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -2,6 +2,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.service;
 
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,6 +11,8 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallenge
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeNote;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeInfoImage;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeCertImage;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeNoteRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
@@ -40,14 +43,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
-                                           MultipartFile mainImage, MultipartFile certImage) {
+                                           List<MultipartFile> infoImages, List<MultipartFile> certImages) {
         // 이미지 파일 검증
-        if (mainImage == null || mainImage.isEmpty()) {
-            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
-        }
-        if (certImage == null || certImage.isEmpty()) {
-            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
-        }
+        validateImages(infoImages, certImages);
 
         // 목표 일수가 전체 기간을 초과하지 않는지 검증
         if (createChallengeReqDTO.getTotalGoalDay() > createChallengeReqDTO.getPeriod().getDays()) {
@@ -75,13 +73,15 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .build());
         member.subPoint(joinPoint); // 포인트 차감
 
-        // S3 이용 챌린지 이미지 저장 로직
-        String mainImageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_MAIN, mainImage);
-        String certImageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_CERT, certImage);
-
         // 챌린지 생성
         Challenge challenge = challengeRepository.save(
-                ChallengeAssembler.toEntity(createChallengeReqDTO, mainImageUrl, certImageUrl));
+                ChallengeAssembler.toEntity(createChallengeReqDTO));
+
+        // 챌린지 정보 이미지들 업로드 및 저장
+        saveInfoImages(challenge, infoImages);
+
+        // 챌린지 인증 이미지들 업로드 및 저장
+        saveCertImages(challenge, certImages);
 
         // ChallengeNote 생성
         challengeNoteRepository.saveAll(createChallengeReqDTO.getNotes().stream()
@@ -108,5 +108,59 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .build());
 
         return ChallengeAssembler.toChallengeResDTO(challenge);
+    }
+
+    private void validateImages(List<MultipartFile> infoImages, List<MultipartFile> certImages) {
+        // 정보 이미지 검증
+        if (infoImages == null || infoImages.isEmpty()) {
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
+        }
+        if (infoImages.size() > 10) { // 최대 10장 제한
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE); // TODO: 적절한 에러 코드로 변경
+        }
+
+        // 인증 이미지 검증
+        if (certImages == null || certImages.isEmpty()) {
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
+        }
+        if (certImages.size() > 5) { // 최대 5장 제한
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE); // TODO: 적절한 에러 코드로 변경
+        }
+
+        // 각 파일 유효성 검증
+        validateEachFile(infoImages);
+        validateEachFile(certImages);
+    }
+
+    private void validateEachFile(List<MultipartFile> files) {
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
+            }
+        }
+    }
+
+    private void saveInfoImages(Challenge challenge, List<MultipartFile> infoImages) {
+        for (int i = 0; i < infoImages.size(); i++) {
+            String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_MAIN, infoImages.get(i));
+            ChallengeInfoImage infoImage = ChallengeInfoImage.builder()
+                    .imageUrl(imageUrl)
+                    .imageOrder(i + 1)
+                    .challenge(challenge)
+                    .build();
+            challenge.getInfoImages().add(infoImage);
+        }
+    }
+
+    private void saveCertImages(Challenge challenge, List<MultipartFile> certImages) {
+        for (int i = 0; i < certImages.size(); i++) {
+            String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_CERT, certImages.get(i));
+            ChallengeCertImage certImage = ChallengeCertImage.builder()
+                    .imageUrl(imageUrl)
+                    .imageOrder(i + 1)
+                    .challenge(challenge)
+                    .build();
+            challenge.getCertImages().add(certImage);
+        }
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -34,6 +34,9 @@ import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 @Transactional
 public class ChallengeServiceImpl implements ChallengeService {
 
+    private static final int MAX_INFO_IMAGE = 5;
+    private static final int MAX_CERT_IMAGE = 4;
+
     private final MemberRepository memberRepository;
     private final ChallengeRepository challengeRepository;
     private final ChallengeMemberRepository challengeMemberRepository;
@@ -115,7 +118,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (infoImages == null || infoImages.isEmpty()) {
             throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
         }
-        if (infoImages.size() > 10) { // 최대 10장 제한
+        if (infoImages.size() > MAX_INFO_IMAGE) { // 최대 10장 제한
             throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE); // TODO: 적절한 에러 코드로 변경
         }
 
@@ -123,7 +126,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (certImages == null || certImages.isEmpty()) {
             throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
         }
-        if (certImages.size() > 5) { // 최대 5장 제한
+        if (certImages.size() > MAX_CERT_IMAGE) { // 최대 5장 제한
             throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE); // TODO: 적절한 에러 코드로 변경
         }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -21,13 +21,13 @@ public class S3Service {
 
     private final S3Client s3Client;
 
-    @Value("${cloud.aws.s3.bucket}")
+    @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
-    @Value("${cloud.aws.s3.path.challenge-main}")
+    @Value("${spring.cloud.aws.s3.path.challenge-main}")
     private String mainPath;
 
-    @Value("${cloud.aws.s3.path.challenge-cert}")
+    @Value("${spring.cloud.aws.s3.path.challenge-cert}")
     private String certPath;
 
     @Value("${spring.cloud.aws.s3.path.member-profile}")

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -1,0 +1,53 @@
+package site.beilsang.beilsang_server_v2.global.aws.s3;
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import site.beilsang.beilsang_server_v2.global.config.AWSConfig;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file) {
+
+        if (file.isEmpty()) {
+            return null;
+        }
+
+        // 파일 이름 설정 로직 추가 필요
+        String fileName = file.getOriginalFilename();
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .key(fileName)
+                    .build();
+            RequestBody requestBody = RequestBody.fromBytes(file.getBytes());
+            s3Client.putObject(putObjectRequest, requestBody);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -1,8 +1,10 @@
 package site.beilsang.beilsang_server_v2.global.aws.s3;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,6 +14,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
@@ -33,7 +36,8 @@ public class S3Service {
     public String uploadFile(UploadPath uploadPath, MultipartFile file) {
 
         if (file.isEmpty()) {
-            return null;
+            log.info("Image is empty");
+            return "";
         }
 
         String path = null;
@@ -47,7 +51,7 @@ public class S3Service {
         }
 
         // 파일 이름 설정
-        String fileName = path + buildFileName(file.getOriginalFilename());
+        String fileName = path + buildFileName(Objects.requireNonNull(file.getOriginalFilename()));
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -1,11 +1,12 @@
 package site.beilsang.beilsang_server_v2.global.aws.s3;
 
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import site.beilsang.beilsang_server_v2.global.config.AWSConfig;
+import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
@@ -20,14 +21,33 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    public String uploadFile(MultipartFile file) {
+    @Value("${cloud.aws.s3.path.challenge-main}")
+    private String mainPath;
+
+    @Value("${cloud.aws.s3.path.challenge-cert}")
+    private String certPath;
+
+    @Value("${spring.cloud.aws.s3.path.member-profile}")
+    private String memberProfilePath;
+
+    public String uploadFile(UploadPath uploadPath, MultipartFile file) {
 
         if (file.isEmpty()) {
             return null;
         }
 
-        // 파일 이름 설정 로직 추가 필요
-        String fileName = file.getOriginalFilename();
+        String path = null;
+        switch (uploadPath) {
+            case CHALLENGE_MAIN:
+                path = mainPath;
+            case CHALLENGE_CERT:
+                path = certPath;
+            case MEMBER_PROFILE:
+                path = memberProfilePath;
+        }
+
+        // 파일 이름 설정
+        String fileName = path + buildFileName(file.getOriginalFilename());
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -50,4 +70,15 @@ public class S3Service {
         return s3Client.utilities().getUrl(getUrlRequest).toString();
     }
 
+    private String buildFileName(String originalFilename) {
+
+        String uuid = UUID.randomUUID().toString();
+
+        int fileExtensionIndex = originalFilename.lastIndexOf(".");
+        String fileExtension = originalFilename.substring(fileExtensionIndex + 1);
+
+        String now = String.valueOf(System.currentTimeMillis());
+
+        return uuid + "_" + now + "." + fileExtension;
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -40,15 +40,11 @@ public class S3Service {
             return "";
         }
 
-        String path = null;
-        switch (uploadPath) {
-            case CHALLENGE_MAIN:
-                path = mainPath;
-            case CHALLENGE_CERT:
-                path = certPath;
-            case MEMBER_PROFILE:
-                path = memberProfilePath;
-        }
+        String path = switch (uploadPath) {
+            case CHALLENGE_MAIN -> mainPath;
+            case CHALLENGE_CERT -> certPath;
+            case MEMBER_PROFILE -> memberProfilePath;
+        };
 
         // 파일 이름 설정
         String fileName = path + buildFileName(Objects.requireNonNull(file.getOriginalFilename()));

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 @Getter
 public enum BaseResponseCode {
 
-    //success
+    // success
     SUCCESS(HttpStatus.OK, "S0001", "요청에 성공했습니다"),
 
     // global
@@ -23,12 +23,17 @@ public enum BaseResponseCode {
     NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "M0001", "존재하지 않은 멤버입니다"),
 
     // point
-    NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "P0001", "포인트가 부족합니다.")
+    NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "P0001", "포인트가 부족합니다."),
+
+    // challenge
+    INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "C0001", "유효하지 않은 이미지 파일입니다"),
+    INVALID_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "C0002", "목표 실천일수가 챌린지 기간을 초과할 수 없습니다"),
+    INVALID_START_DATE(HttpStatus.BAD_REQUEST, "C0003", "시작 날짜는 오늘 이후여야 합니다")
 
     ;
 
-    private final HttpStatus status; //커스텀 상태코드
-    private final String code;  //Http 상태코드
+    private final HttpStatus status; // 커스텀 상태코드
+    private final String code; // Http 상태코드
     private final String message;
 
     public static BaseResponseCode findByCode(String code) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/AWSConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/AWSConfig.java
@@ -1,0 +1,49 @@
+package site.beilsang.beilsang_server_v2.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@Getter
+public class AWSConfig {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    @Primary
+    public AwsCredentials awsCredentials() {
+        return new AwsCredentials() {
+            @Override
+            public String accessKeyId() {
+                return accessKey;
+            }
+
+            @Override
+            public String secretAccessKey() {
+                return secretKey;
+            }
+        };
+    }
+
+    @Bean
+    @Primary
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(this::awsCredentials)
+                .region(Region.of(region))
+                .build();
+    }
+
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/AWSConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/AWSConfig.java
@@ -12,13 +12,13 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 @Getter
 public class AWSConfig {
-    @Value("${cloud.aws.credentials.accessKey}")
+    @Value("${spring.cloud.aws.credentials.accessKey}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secretKey}")
+    @Value("${spring.cloud.aws.credentials.secretKey}")
     private String secretKey;
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${spring.cloud.aws.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/UploadPath.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/UploadPath.java
@@ -1,0 +1,7 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum UploadPath {
+    CHALLENGE_MAIN,
+    CHALLENGE_CERT,
+    MEMBER_PROFILE
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,16 +25,16 @@ spring:
   cloud:
     aws:
       credentials:
-        access-key: ${AWS_ACCESS_KEY_ID}
-        secret-key: ${AWS_SECRET_ACCESS_KEY}
+        accessKey: ${AWS_ACCESS_KEY_ID}
+        secretKey: ${AWS_SECRET_ACCESS_KEY}
       region:
         static: ap-northeast-2
       s3:
         bucket: beilsang-bucket-dev
         path:
-            challenge-main: challenge/main
-            challenge-cert: challenge/cert
-            member-profile: member/profile
+          challenge-main: challenge/main
+          challenge-cert: challenge/cert
+          member-profile: member/profile
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,5 +22,19 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token # 토큰 요청 uri
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: beilsang-bucket-dev
+        path:
+            challenge-main: challenge/main
+            challenge-cert: challenge/cert
+            member-profile: member/profile
+
 jwt:
   secret-key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- closed #10

## 🍬 기능 설명
- **AWS S3 이미지 업로드 기능 구현**
  - S3Client를 활용한 이미지 파일 업로드 서비스 구현
  - UUID와 timestamp를 활용한 고유 파일명 생성 로직
  - 챌린지 정보용/인증용/프로필용 이미지 경로 구분 처리

- **챌린지 이미지 다중 업로드 지원**
  - 챌린지 생성 시 여러 장의 정보 이미지(최대 5장) 업로드 가능
  - 챌린지 인증 예시 이미지(최대 4장) 업로드 가능
  - `ChallengeInfoImage`, `ChallengeCertImage` 엔티티 추가로 일대다 관계 처리

- **이미지 업로드 유효성 검증 강화**
  - 이미지 파일 null/empty 검증
  - 이미지 개수 제한 검증
  - 목표 실천일수가 챌린지 전체 기간을 초과하지 않는지 검증
  - 챌린지 시작 날짜가 과거가 아닌지 검증

## 🤔 코드 리뷰에서 집중적으로 볼 내용
<!-- 코드를 작성하면서 헷갈렸던 부분을 캡처/복사해서 넣자 -->

**이미지 엔티티와 Challenge 간 양방향 연관관계 처리**
```145:170:src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
private void saveInfoImages(Challenge challenge, List<MultipartFile> infoImages) {
    for (int i = 0; i < infoImages.size(); i++) {
        String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_MAIN, infoImages.get(i));
        ChallengeInfoImage infoImage = ChallengeInfoImage.builder()
                .imageUrl(imageUrl)
                .imageOrder(i + 1)
                .challenge(challenge)
                .build();
        challenge.getInfoImages().add(infoImage);
    }
}
```
엔티티 저장 시 영속성 컨텍스트 관리와 cascade 설정 확인이 필요합니다.

## ⭐ 기타 사항
<!-- 개발할 때 참고했던 레퍼런스나 공유하면 좋을 것들을 나눠보아요 -->
- AWS SDK v2 사용하여 S3Client 구현
- Spring Boot 3.x 환경에서의 AWS 설정 방식 적용
- JPA 일대다 양방향 연관관계 매핑으로 이미지 엔티티 관리
- 이미지 업로드 시 순서(imageOrder) 정보도 함께 저장하여 클라이언트에서 순서대로 표시 가능