### PR TITLE
[Feat] 챌린지 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ dependencies {
 
 	// AWS S3
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
+
+	//QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -38,7 +38,9 @@ public class ChallengeController {
 
     @GetMapping
     public BaseResponse<PageResponseDTO<ChallengeListResponseDTO>> getChallengeList(
+            Authentication authentication,
             @ModelAttribute ChallengeListRequestDTO requestDTO) {
+        Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.getChallengeList(requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -41,6 +41,7 @@ public class ChallengeController {
             Authentication authentication,
             @ModelAttribute ChallengeListRequestDTO requestDTO) {
         Long memberId = (Long) authentication.getPrincipal();
+        requestDTO.setMemberId(memberId);
         return new BaseResponse<>(challengeService.getChallengeList(requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -3,15 +3,20 @@ package site.beilsang.beilsang_server_v2.domain.challenge.controller;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.service.ChallengeService;
 import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
+import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
 
 @RestController
 @RequestMapping("/challenge")
@@ -29,5 +34,11 @@ public class ChallengeController {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(
                 challengeService.createChallenge(memberId, createChallengeReqDTO, infoImages, certImages));
+    }
+
+    @GetMapping
+    public BaseResponse<PageResponseDTO<ChallengeListResponseDTO>> getChallengeList(
+            @ModelAttribute ChallengeListRequestDTO requestDTO) {
+        return new BaseResponse<>(challengeService.getChallengeList(requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -6,55 +6,73 @@ import org.springframework.stereotype.Component;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
 
 @Slf4j
 @Component
 public class ChallengeAssembler {
 
-    public static Challenge toEntity(CreateChallengeReqDTO request) {
-        return Challenge.builder()
-                .category(request.getCategory())
-                .title(request.getTitle())
-                .startDate(request.getStartDate())
-                .finishDate(request.getStartDate().plusDays(request.getPeriod().getDays() - 1))
-                .joinPoint(request.getJoinPoint())
-                .details(request.getDetails())
-                .period(request.getPeriod())
-                .totalGoalDay(request.getTotalGoalDay())
-                .attendeeCount(1)
-                .countLikes(0)
-                .collectedPoint(request.getJoinPoint())
-                .build();
-    }
+        public static Challenge toEntity(CreateChallengeReqDTO request) {
+                return Challenge.builder()
+                                .category(request.getCategory())
+                                .title(request.getTitle())
+                                .startDate(request.getStartDate())
+                                .finishDate(request.getStartDate().plusDays(request.getPeriod().getDays() - 1))
+                                .joinPoint(request.getJoinPoint())
+                                .details(request.getDetails())
+                                .period(request.getPeriod())
+                                .totalGoalDay(request.getTotalGoalDay())
+                                .attendeeCount(1)
+                                .countLikes(0)
+                                .collectedPoint(request.getJoinPoint())
+                                .build();
+        }
 
-    public static ChallengeResDTO toChallengeResDTO(Challenge challenge) {
-        // 정보 이미지 URL 리스트 생성
-        List<String> infoImageUrls = challenge.getInfoImages().stream()
-                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
-                .map(image -> image.getImageUrl())
-                .toList();
+        public static ChallengeResDTO toChallengeResDTO(Challenge challenge) {
+                // 정보 이미지 URL 리스트 생성
+                List<String> infoImageUrls = challenge.getInfoImages().stream()
+                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                                .map(image -> image.getImageUrl())
+                                .toList();
 
-        // 인증 이미지 URL 리스트 생성
-        List<String> certImageUrls = challenge.getCertImages().stream()
-                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
-                .map(image -> image.getImageUrl())
-                .toList();
+                // 인증 이미지 URL 리스트 생성
+                List<String> certImageUrls = challenge.getCertImages().stream()
+                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                                .map(image -> image.getImageUrl())
+                                .toList();
 
-        return ChallengeResDTO.builder()
-                .challengeId(challenge.getId())
-                .category(challenge.getCategory())
-                .title(challenge.getTitle())
-                .startDate(challenge.getStartDate())
-                .finishDate(challenge.getFinishDate())
-                .joinPoint(challenge.getJoinPoint())
-                .infoImageUrls(infoImageUrls)
-                .certImageUrls(certImageUrls)
-                .details(challenge.getDetails())
-                .period(challenge.getPeriod())
-                .totalGoalDay(challenge.getTotalGoalDay())
-                .attendeeCount(challenge.getAttendeeCount())
-                .countLikes(challenge.getCountLikes())
-                .collectedPoint(challenge.getCollectedPoint())
-                .build();
-    }
+                return ChallengeResDTO.builder()
+                                .challengeId(challenge.getId())
+                                .category(challenge.getCategory())
+                                .title(challenge.getTitle())
+                                .startDate(challenge.getStartDate())
+                                .finishDate(challenge.getFinishDate())
+                                .joinPoint(challenge.getJoinPoint())
+                                .infoImageUrls(infoImageUrls)
+                                .certImageUrls(certImageUrls)
+                                .details(challenge.getDetails())
+                                .period(challenge.getPeriod())
+                                .totalGoalDay(challenge.getTotalGoalDay())
+                                .attendeeCount(challenge.getAttendeeCount())
+                                .countLikes(challenge.getCountLikes())
+                                .collectedPoint(challenge.getCollectedPoint())
+                                .build();
+        }
+
+        public static ChallengeListResponseDTO toChallengeListResponseDTO(Challenge challenge) {
+                String imageUrl = null;
+                if (!challenge.getInfoImages().isEmpty()) {
+                        imageUrl = challenge.getInfoImages().get(0).getImageUrl();
+                }
+                return ChallengeListResponseDTO.builder()
+                                .id(challenge.getId())
+                                .title(challenge.getTitle())
+                                .category(challenge.getCategory())
+                                .status(null) // TODO: ChallengeStatus 추가
+                                .participantCount(challenge.getAttendeeCount())
+                                .likeCount(challenge.getCountLikes())
+                                .imageUrl(imageUrl)
+                                .description(challenge.getDetails())
+                                .build();
+        }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
@@ -14,4 +14,7 @@ public class ChallengeListRequestDTO {
     private Category category;
     private ChallengeStatus status;
     private String keyword;
+    private Boolean isFinished;
+    private Boolean isJoined;
+    private Long memberId;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
@@ -1,0 +1,17 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+
+@Getter
+@Setter
+public class ChallengeListRequestDTO {
+    private Integer page = 0;
+    private Integer size = 10;
+    private String sort; // 예: "attendeeCount,desc"
+    private Category category;
+    private ChallengeStatus status;
+    private String keyword;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeSortField;
+import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
 @Getter
 @Setter
 public class ChallengeListRequestDTO {
     private Integer page = 0;
     private Integer size = 10;
-    private String sort; // 예: "attendeeCount,desc"
+    private ChallengeSortField sortField = ChallengeSortField.FINISH_DATE;
+    private SortDirection sortDirection = SortDirection.DESC;
     private Category category;
     private ChallengeStatus status;
     private String keyword;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResponseDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResponseDTO.java
@@ -1,0 +1,23 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeListResponseDTO {
+    private Long id;
+    private String title;
+    private Category category;
+    private ChallengeStatus status;
+    private int participantCount;
+    private int likeCount;
+    private String imageUrl;
+    private String description;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
@@ -3,5 +3,5 @@ package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 
-public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeRepositoryCustom {
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+
+public interface ChallengeRepositoryCustom {
+    Page<Challenge> findChallenges(ChallengeListRequestDTO requestDTO, Pageable pageable);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -8,9 +8,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
-import site.beilsang.beilsang_server_v2.domain.member.entity.QChallengeMember;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -38,7 +38,6 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         }
         // isJoined 필터링
         if (requestDTO.getIsJoined() != null && requestDTO.getMemberId() != null) {
-            QChallengeMember challengeMember = QChallengeMember.challengeMember;
             if (requestDTO.getIsJoined()) {
                 builder.and(challenge.challengeMembers.any().member.id.eq(requestDTO.getMemberId()));
             } else {
@@ -51,15 +50,16 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
                 .where(builder);
 
         // 정렬 처리
-        pageable.getSort().forEach(order -> {
-            if (order.getProperty().equals("countLikes")) {
-                query.orderBy(order.isAscending() ? challenge.countLikes.asc() : challenge.countLikes.desc());
-            } else if (order.getProperty().equals("startDate")) {
-                query.orderBy(order.isAscending() ? challenge.startDate.asc() : challenge.startDate.desc());
-            } else if (order.getProperty().equals("endDate")) {
-                query.orderBy(order.isAscending() ? challenge.finishDate.asc() : challenge.finishDate.desc());
+        if (requestDTO.getSortField() != null && requestDTO.getSortDirection() != null) {
+            boolean asc = SortDirection.ASC == requestDTO
+                    .getSortDirection();
+            switch (requestDTO.getSortField()) {
+                case ATTENDEE_COUNT -> query.orderBy(asc ? challenge.attendeeCount.asc() : challenge.attendeeCount.desc());
+                case COUNT_LIKES -> query.orderBy(asc ? challenge.countLikes.asc() : challenge.countLikes.desc());
+                case START_DATE -> query.orderBy(asc ? challenge.startDate.asc() : challenge.startDate.desc());
+                case FINISH_DATE -> query.orderBy(asc ? challenge.finishDate.asc() : challenge.finishDate.desc());
             }
-        });
+        }
 
         // 페이징
         List<Challenge> content = query

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -1,6 +1,7 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -67,9 +68,11 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
                 .fetch();
 
         // 전체 개수 쿼리
-        long total = queryFactory.selectFrom(challenge)
+        long total = queryFactory
+                .select(Wildcard.count)
+                .from(challenge)
                 .where(builder)
-                .fetchCount();
+                .fetchOne();
 
         return new PageImpl<>(content, pageable, total);
     }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -1,0 +1,19 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+
+@RequiredArgsConstructor
+public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Challenge> findChallenges(ChallengeListRequestDTO requestDTO, Pageable pageable) {
+        // TODO: QueryDSL 동적 쿼리 구현 예정
+        return null;
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -1,11 +1,17 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
+import site.beilsang.beilsang_server_v2.domain.member.entity.QChallengeMember;
+import java.time.LocalDate;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
@@ -13,7 +19,58 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
 
     @Override
     public Page<Challenge> findChallenges(ChallengeListRequestDTO requestDTO, Pageable pageable) {
-        // TODO: QueryDSL 동적 쿼리 구현 예정
-        return null;
+        QChallenge challenge = QChallenge.challenge;
+        BooleanBuilder builder = new BooleanBuilder();
+        LocalDate today = LocalDate.now();
+
+        // 카테고리 필터링
+        if (requestDTO.getCategory() != null) {
+            builder.and(challenge.category.eq(requestDTO.getCategory()));
+        }
+        // isFinished 필터링
+        if (requestDTO.getIsFinished() != null) {
+            if (requestDTO.getIsFinished()) {
+                builder.and(challenge.finishDate.lt(today));
+            } else {
+                builder.and(challenge.finishDate.goe(today));
+            }
+        }
+        // isJoined 필터링
+        if (requestDTO.getIsJoined() != null && requestDTO.getMemberId() != null) {
+            QChallengeMember challengeMember = QChallengeMember.challengeMember;
+            if (requestDTO.getIsJoined()) {
+                builder.and(challenge.challengeMembers.any().member.id.eq(requestDTO.getMemberId()));
+            } else {
+                builder.and(challenge.challengeMembers.any().member.id.ne(requestDTO.getMemberId()));
+            }
+        }
+
+        // 기본 쿼리
+        var query = queryFactory.selectFrom(challenge)
+                .where(builder);
+
+        // 정렬 처리
+        pageable.getSort().forEach(order -> {
+            if (order.getProperty().equals("countLikes")) {
+                query.orderBy(order.isAscending() ? challenge.countLikes.asc() : challenge.countLikes.desc());
+            } else if (order.getProperty().equals("startDate")) {
+                query.orderBy(order.isAscending() ? challenge.startDate.asc() : challenge.startDate.desc());
+            } else if (order.getProperty().equals("endDate")) {
+                query.orderBy(order.isAscending() ? challenge.finishDate.asc() : challenge.finishDate.desc());
+            }
+        });
+
+        // 페이징
+        List<Challenge> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 개수 쿼리
+        long total = queryFactory.selectFrom(challenge)
+                .where(builder)
+                .fetchCount();
+
+        return new PageImpl<>(content, pageable, total);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -1,6 +1,7 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.service;
 
 import java.util.List;
+import lombok.extern.java.Log;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -4,9 +4,14 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
+import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
 
 public interface ChallengeService {
 
     ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
             List<MultipartFile> infoImages, List<MultipartFile> certImages);
+
+    PageResponseDTO<ChallengeListResponseDTO> getChallengeList(ChallengeListRequestDTO requestDTO);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -1,7 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.service;
 
 import java.util.List;
-import lombok.extern.java.Log;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -28,6 +28,9 @@ import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
+import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +49,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
-                                           List<MultipartFile> infoImages, List<MultipartFile> certImages) {
+            List<MultipartFile> infoImages, List<MultipartFile> certImages) {
         // 이미지 파일 검증
         validateImages(infoImages, certImages);
 
@@ -165,5 +168,11 @@ public class ChallengeServiceImpl implements ChallengeService {
                     .build();
             challenge.getCertImages().add(certImage);
         }
+    }
+
+    @Override
+    public PageResponseDTO<ChallengeListResponseDTO> getChallengeList(ChallengeListRequestDTO requestDTO) {
+        // TODO: 구현 예정
+        return null;
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -31,6 +31,10 @@ import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
 import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -172,7 +176,20 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public PageResponseDTO<ChallengeListResponseDTO> getChallengeList(ChallengeListRequestDTO requestDTO) {
-        // TODO: 구현 예정
-        return null;
+        Pageable pageable = PageRequest.of(
+                requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+                requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+        Page<Challenge> page = challengeRepository.findChallenges(requestDTO, pageable);
+        List<ChallengeListResponseDTO> content = page.getContent().stream()
+                .map(ChallengeAssembler::toChallengeListResponseDTO)
+                .collect(Collectors.toList());
+        return PageResponseDTO.<ChallengeListResponseDTO>builder()
+                .content(content)
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .hasNext(page.hasNext())
+                .build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/PageResponseDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/PageResponseDTO.java
@@ -1,0 +1,20 @@
+package site.beilsang.beilsang_server_v2.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageResponseDTO<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/QueryDslConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package site.beilsang.beilsang_server_v2.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeSortField.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeSortField.java
@@ -1,0 +1,8 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum ChallengeSortField {
+    ATTENDEE_COUNT,
+    COUNT_LIKES,
+    START_DATE,
+    FINISH_DATE
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/SortDirection.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/SortDirection.java
@@ -1,0 +1,6 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum SortDirection {
+    ASC,
+    DESC
+}

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
@@ -15,7 +15,6 @@ import site.beilsang.beilsang_server_v2.global.enums.Category;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
@@ -1,0 +1,88 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.global.config.QueryDslConfig;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class ChallengeRepositoryImplTest {
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Test
+    @DisplayName("isFinished=true이면 종료된 챌린지만 조회된다")
+    void findFinishedChallenges() {
+        // given
+        Challenge finished = Challenge.builder()
+                .title("종료된 챌린지")
+                .category(Category.BIKE)
+                .startDate(LocalDate.now().minusDays(10))
+                .finishDate(LocalDate.now().minusDays(1))
+                .build();
+        Challenge ongoing = Challenge.builder()
+                .title("진행중 챌린지")
+                .category(Category.BIKE)
+                .startDate(LocalDate.now().minusDays(1))
+                .finishDate(LocalDate.now().plusDays(5))
+                .build();
+        challengeRepository.save(finished);
+        challengeRepository.save(ongoing);
+
+        ChallengeListRequestDTO dto = new ChallengeListRequestDTO();
+        dto.setIsFinished(true);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Challenge> result = challengeRepository.findChallenges(dto, pageable);
+
+        // then
+        assertThat(result.stream().count()).isEqualTo(1);
+        assertThat(result.getContent()).extracting("title").containsExactly("종료된 챌린지");
+    }
+
+    @Test
+    @DisplayName("isFinished=false이면 아직 종료되지 않은 챌린지만 조회된다")
+    void findOngoingChallenges() {
+        // given
+        Challenge finished = Challenge.builder()
+                .title("종료된 챌린지")
+                .category(Category.BIKE)
+                .startDate(LocalDate.now().minusDays(10))
+                .finishDate(LocalDate.now().minusDays(1))
+                .build();
+        Challenge ongoing = Challenge.builder()
+                .title("진행중 챌린지")
+                .category(Category.BIKE)
+                .startDate(LocalDate.now().minusDays(1))
+                .finishDate(LocalDate.now().plusDays(5))
+                .build();
+        challengeRepository.save(finished);
+        challengeRepository.save(ongoing);
+
+        ChallengeListRequestDTO dto = new ChallengeListRequestDTO();
+        dto.setIsFinished(false);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Challenge> result = challengeRepository.findChallenges(dto, pageable);
+
+        // then
+        assertThat(result.getContent()).extracting("title").containsExactly("진행중 챌린지");
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- closed #19

---

## 🍬 기능 설명
- 챌린지 목록 조회 API 구현 (`GET /challenge`)
  - 페이징, 카테고리, 종료여부, 참여여부, 정렬(참여인원/좋아요/시작일/종료일) 지원
  - 정렬 기준 및 방향을 Enum(`ChallengeSortField`, `SortDirection`)으로 관리하여 오타 방지 및 유지보수성 향상
  - QueryDSL 기반 동적 쿼리로 필터링/정렬/페이징 처리
  - 참여여부(`isJoined`), 종료여부(`isFinished`) 필터링 조건

---

## 🤔 코드 리뷰에서 집중적으로 볼 내용
- 정렬 기준/방향 Enum 도입 및 QueryDSL 정렬 분기 처리 방식
- 참여여부(`isJoined`), 종료여부(`isFinished`) 필터링의 동적 쿼리 구현
- 컨트롤러에서 인증 정보(`Authentication`)로부터 memberId 추출 및 DTO에 세팅하는 방식
  - _setter를 사용하는 것이 최선의 방식일까?_
- Challenge → ChallengeListResponseDTO 변환 로직(Assembler)
- 테스트 코드에서 실제 데이터로 동작 검증

---

## ⭐ 기타 사항
- 이후 작업으로, Challenge 엔티티에 `challengeStatus`(진행상태) 속성 추가가 필요합니다.
  - 예: 진행중/예정/완료 등 상태를 명확히 Enum으로 관리
  - ChallengeMember의 상태와 구분이 필요할 거 같습니다.
    - ChallengeStatus와 ChallengeMemberStatus 두가지 enum 클래스 모두 '진행중'이라는 값이 필요할 거 같은데, 이때의 변수명을 어떻게 하는게 좋을지도 의견주시면 감사하겠습니다.
- `challengeStatus` 추가 후, 관련 비즈니스 로직 및 DTO/쿼리/테스트 리팩터링 예정