### PR TITLE
[Refac] ChallengeStatus를 ChallengeMemberStatus로 수정

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -68,7 +68,7 @@ public class ChallengeAssembler {
                                 .id(challenge.getId())
                                 .title(challenge.getTitle())
                                 .category(challenge.getCategory())
-                                .status(null) // TODO: ChallengeStatus 추가
+                                .status(null) // TODO: ChallengeMemberStatus 추가
                                 .participantCount(challenge.getAttendeeCount())
                                 .likeCount(challenge.getCountLikes())
                                 .imageUrl(imageUrl)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListRequestDTO.java
@@ -3,7 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeSortField;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
@@ -15,7 +15,7 @@ public class ChallengeListRequestDTO {
     private ChallengeSortField sortField = ChallengeSortField.FINISH_DATE;
     private SortDirection sortDirection = SortDirection.DESC;
     private Category category;
-    private ChallengeStatus status;
+    private ChallengeMemberStatus status;
     private String keyword;
     private Boolean isFinished;
     private Boolean isJoined;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResponseDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResponseDTO.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Getter
 @Builder
@@ -15,7 +15,7 @@ public class ChallengeListResponseDTO {
     private Long id;
     private String title;
     private Category category;
-    private ChallengeStatus status;
+    private ChallengeMemberStatus status;
     private int participantCount;
     private int likeCount;
     private String imageUrl;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -24,7 +24,7 @@ import site.beilsang.beilsang_server_v2.domain.point.repository.PointLogReposito
 import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
@@ -101,17 +101,17 @@ public class ChallengeServiceImpl implements ChallengeService {
                         .build())
                 .toList());
 
-        // ChallengeStatus 상태 결정
-        ChallengeStatus challengeStatus = ChallengeStatus.ONGOING;
+        // ChallengeMemberStatus 상태 결정
+        ChallengeMemberStatus challengeMemberStatus = site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus.ONGOING;
         if (createChallengeReqDTO.getStartDate().isAfter(LocalDate.now())) {
-            challengeStatus = ChallengeStatus.NOT_YET;
+            challengeMemberStatus = ChallengeMemberStatus.NOT_YET;
         }
 
         // ChallengeMember 생성
         challengeMemberRepository.save(ChallengeMember.builder()
                 .isHost(true)
                 .successDays(0)
-                .challengeStatus(challengeStatus)
+                .challengeMemberStatus(challengeMemberStatus)
                 .isFeedUpload(false)
                 .member(member)
                 .challenge(challenge)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
 import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 
 import java.util.ArrayList;
 import java.util.List;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Entity
 @Getter
@@ -29,7 +29,7 @@ public class ChallengeMember extends BaseEntity {
     private Integer successDays;
 
     @Enumerated(EnumType.STRING)
-    private ChallengeStatus challengeStatus;
+    private ChallengeMemberStatus challengeMemberStatus;
 
     private Boolean isFeedUpload;
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Repository
 public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
@@ -13,7 +13,7 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
     List<ChallengeMember> findAllByMemberId(Long memberId);
 
     //count
-    Long countByMemberIdAndChallengeStatus(Long memberId, ChallengeStatus challengeStatus);
+    Long countByMemberIdAndChallengeStatus(Long memberId, ChallengeMemberStatus challengeMemberStatus);
     Long countByMemberId(Long memberId);
 
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
@@ -23,11 +23,11 @@ import site.beilsang.beilsang_server_v2.domain.uuid.entity.Uuid;
 import site.beilsang.beilsang_server_v2.domain.uuid.repository.UuidRepository;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Service
 @RequiredArgsConstructor
@@ -55,13 +55,13 @@ public class MemberService {
         Long countFeed = feedRepository.countByChallengeMember_IdIn(challengeMemberIds);
 
         //달성한 챌린지 개수
-        Long countSuccessChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeStatus.SUCCESS);
+        Long countSuccessChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus.SUCCESS);
 
         // 챌린지 개수 : 멤버 아이디로 챌린지멤버 테이블 카운트
         Long countChallenge = challengeMemberRepository.countByMemberId(memberId);
 
         // 실패한 챌린지 개수
-        Long countFailedChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeStatus.FAIL);
+        Long countFailedChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeMemberStatus.FAIL);
 
         // 찜 개수 : 회원 아이디로 챌린지라이크 테이블 접근해서 카운트
         Long countlike = challengeLikeRepository.countByMemberId(memberId);

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeMemberStatus.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeMemberStatus.java
@@ -1,6 +1,6 @@
 package site.beilsang.beilsang_server_v2.global.enums;
 
-public enum ChallengeStatus {
+public enum ChallengeMemberStatus {
 
     SUCCESS, FAIL, ONGOING, NOT_YET
 }

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -13,7 +13,6 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
-import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeNote;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeNoteRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
@@ -35,7 +34,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -173,7 +171,8 @@ class ChallengeServiceImplTest {
         ArgumentCaptor<ChallengeMember> challengeMemberCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
         verify(challengeMemberRepository).save(challengeMemberCaptor.capture());
         ChallengeMember savedChallengeMember = challengeMemberCaptor.getValue();
-        assertThat(savedChallengeMember.getChallengeStatus()).isEqualTo(ChallengeStatus.NOT_YET);
+        assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(
+                site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus.NOT_YET);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class), any(MultipartFile.class));
     }
 
@@ -200,7 +199,8 @@ class ChallengeServiceImplTest {
         ArgumentCaptor<ChallengeMember> challengeMemberCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
         verify(challengeMemberRepository).save(challengeMemberCaptor.capture());
         ChallengeMember savedChallengeMember = challengeMemberCaptor.getValue();
-        assertThat(savedChallengeMember.getChallengeStatus()).isEqualTo(ChallengeStatus.ONGOING);
+        assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(
+                site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus.ONGOING);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class), any(MultipartFile.class));
     }
 


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- closed #22 

## 🍬 기능 설명
- 기존 ChallengeMember의 상태(성공, 실패, 진행 중, 아직 시작 안함)를 ChallengeStatus로 두어 챌린지의 상태와 혼동되는 문제를 해결하고자 enum 및 연관 변수명을 ChallengeMemberStatus로 변경하였습니다.
- Challenge 엔티티에 상태(시작 안함, 진행 중, 완료됨)를 나타내는 속성을 추가해야 하나 고민을 하다, startTime, finishTime을 이용하여 필요한 때에 계산하는 방식이 덜 복잡할 것으로 판단되어 기존의 방식을 유지하기로 결정했습니다.

## 🤔 코드 리뷰에서 집중적으로 볼 내용
<!-- 코드를 작성하면서 헷갈렸던 부분을 캡처/복사해서 넣자 -->
- ChallengeStatus가 없는 지금의 방식이 괜찮은지

## ⭐ 기타 사항
<!-- 개발할 때 참고했던 레퍼런스나 공유하면 좋을 것들을 나눠보아요 -->
