### PR TITLE
[Feat] 챌린지 상세조회 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -5,14 +5,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.service.ChallengeService;
 import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
@@ -37,11 +39,18 @@ public class ChallengeController {
     }
 
     @GetMapping
-    public BaseResponse<PageResponseDTO<ChallengeListResponseDTO>> getChallengeList(
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getChallengeList(
             Authentication authentication,
-            @ModelAttribute ChallengeListRequestDTO requestDTO) {
+            @ModelAttribute ChallengeListReqDTO requestDTO) {
         Long memberId = (Long) authentication.getPrincipal();
         requestDTO.setMemberId(memberId);
         return new BaseResponse<>(challengeService.getChallengeList(requestDTO));
+    }
+
+    @GetMapping("/{challengeId}")
+    public BaseResponse<ChallengeDetailResDTO> getChallengeDetail(
+            @PathVariable Long challengeId) {
+        // TODO: 서비스 호출 및 상세 정보 반환 구현
+        return null;
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -49,8 +49,9 @@ public class ChallengeController {
 
     @GetMapping("/{challengeId}")
     public BaseResponse<ChallengeDetailResDTO> getChallengeDetail(
-            @PathVariable Long challengeId) {
-        // TODO: 서비스 호출 및 상세 정보 반환 구현
-        return null;
+            @PathVariable Long challengeId,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(challengeService.getChallengeDetail(challengeId, memberId));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -8,106 +8,111 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 
 @Slf4j
 @Component
 public class ChallengeAssembler {
 
-        public static Challenge toEntity(CreateChallengeReqDTO request) {
-                return Challenge.builder()
-                                .category(request.getCategory())
-                                .title(request.getTitle())
-                                .startDate(request.getStartDate())
-                                .finishDate(request.getStartDate().plusDays(request.getPeriod().getDays() - 1))
-                                .joinPoint(request.getJoinPoint())
-                                .details(request.getDetails())
-                                .period(request.getPeriod())
-                                .totalGoalDay(request.getTotalGoalDay())
-                                .attendeeCount(1)
-                                .countLikes(0)
-                                .collectedPoint(request.getJoinPoint())
-                                .build();
+    public static Challenge toEntity(CreateChallengeReqDTO request) {
+        return Challenge.builder()
+                .category(request.getCategory())
+                .title(request.getTitle())
+                .startDate(request.getStartDate())
+                .finishDate(request.getStartDate().plusDays(request.getPeriod().getDays() - 1))
+                .joinPoint(request.getJoinPoint())
+                .details(request.getDetails())
+                .period(request.getPeriod())
+                .totalGoalDay(request.getTotalGoalDay())
+                .attendeeCount(1)
+                .countLikes(0)
+                .collectedPoint(request.getJoinPoint())
+                .build();
+    }
+
+    public static ChallengeResDTO toChallengeResDTO(Challenge challenge) {
+        // 정보 이미지 URL 리스트 생성
+        List<String> infoImageUrls = challenge.getInfoImages().stream()
+                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                .map(image -> image.getImageUrl())
+                .toList();
+
+        // 인증 이미지 URL 리스트 생성
+        List<String> certImageUrls = challenge.getCertImages().stream()
+                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                .map(image -> image.getImageUrl())
+                .toList();
+
+        return ChallengeResDTO.builder()
+                .challengeId(challenge.getId())
+                .category(challenge.getCategory())
+                .title(challenge.getTitle())
+                .startDate(challenge.getStartDate())
+                .finishDate(challenge.getFinishDate())
+                .joinPoint(challenge.getJoinPoint())
+                .infoImageUrls(infoImageUrls)
+                .certImageUrls(certImageUrls)
+                .details(challenge.getDetails())
+                .period(challenge.getPeriod())
+                .totalGoalDay(challenge.getTotalGoalDay())
+                .attendeeCount(challenge.getAttendeeCount())
+                .countLikes(challenge.getCountLikes())
+                .collectedPoint(challenge.getCollectedPoint())
+                .build();
+    }
+
+    public static ChallengeListResDTO toChallengeListResDTO(Challenge challenge) {
+        String imageUrl = null;
+        if (!challenge.getInfoImages().isEmpty()) {
+            imageUrl = challenge.getInfoImages().get(0).getImageUrl();
         }
+        return ChallengeListResDTO.builder()
+                .id(challenge.getId())
+                .title(challenge.getTitle())
+                .category(challenge.getCategory())
+                .status(null) // TODO: ChallengeStatus 추가
+                .participantCount(challenge.getAttendeeCount())
+                .likeCount(challenge.getCountLikes())
+                .imageUrl(imageUrl)
+                .description(challenge.getDetails())
+                .build();
+    }
 
-        public static ChallengeResDTO toChallengeResDTO(Challenge challenge) {
-                // 정보 이미지 URL 리스트 생성
-                List<String> infoImageUrls = challenge.getInfoImages().stream()
-                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
-                                .map(image -> image.getImageUrl())
-                                .toList();
+    public static ChallengeDetailResDTO toChallengeDetailResDTO(
+            Challenge challenge, boolean isJoinable, ChallengeStatus status, Float progress
+    ) {
+        List<String> infoImageUrls = challenge.getInfoImages().stream()
+                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                .map(image -> image.getImageUrl())
+                .toList();
 
-                // 인증 이미지 URL 리스트 생성
-                List<String> certImageUrls = challenge.getCertImages().stream()
-                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
-                                .map(image -> image.getImageUrl())
-                                .toList();
+        List<String> certImageUrls = challenge.getCertImages().stream()
+                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                .map(image -> image.getImageUrl())
+                .toList();
 
-                return ChallengeResDTO.builder()
-                                .challengeId(challenge.getId())
-                                .category(challenge.getCategory())
-                                .title(challenge.getTitle())
-                                .startDate(challenge.getStartDate())
-                                .finishDate(challenge.getFinishDate())
-                                .joinPoint(challenge.getJoinPoint())
-                                .infoImageUrls(infoImageUrls)
-                                .certImageUrls(certImageUrls)
-                                .details(challenge.getDetails())
-                                .period(challenge.getPeriod())
-                                .totalGoalDay(challenge.getTotalGoalDay())
-                                .attendeeCount(challenge.getAttendeeCount())
-                                .countLikes(challenge.getCountLikes())
-                                .collectedPoint(challenge.getCollectedPoint())
-                                .build();
-        }
+        List<String> challengeNotes = challenge.getChallengeNotes().stream()
+                .map(note -> note.getNote())
+                .toList();
 
-        public static ChallengeListResDTO toChallengeListResDTO(Challenge challenge) {
-                String imageUrl = null;
-                if (!challenge.getInfoImages().isEmpty()) {
-                        imageUrl = challenge.getInfoImages().get(0).getImageUrl();
-                }
-                return ChallengeListResDTO.builder()
-                                .id(challenge.getId())
-                                .title(challenge.getTitle())
-                                .category(challenge.getCategory())
-                                .status(null) // TODO: ChallengeStatus 추가
-                                .participantCount(challenge.getAttendeeCount())
-                                .likeCount(challenge.getCountLikes())
-                                .imageUrl(imageUrl)
-                                .description(challenge.getDetails())
-                                .build();
-        }
-
-        public static ChallengeDetailResDTO toChallengeDetailResDTO(Challenge challenge) {
-                List<String> infoImageUrls = challenge.getInfoImages().stream()
-                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
-                                .map(image -> image.getImageUrl())
-                                .toList();
-
-                List<String> certImageUrls = challenge.getCertImages().stream()
-                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
-                                .map(image -> image.getImageUrl())
-                                .toList();
-
-                List<String> challengeNotes = challenge.getChallengeNotes().stream()
-                                .map(note -> note.getNote())
-                                .toList();
-
-                return ChallengeDetailResDTO.builder()
-                                .challengeId(challenge.getId())
-                                .title(challenge.getTitle())
-                                .description(challenge.getDetails())
-                                .category(challenge.getCategory())
-                                .status(null) // TODO: ChallengeStatus 매핑 필요시 추가
-                                .startDate(challenge.getStartDate())
-                                .finishDate(challenge.getFinishDate())
-                                .period(challenge.getPeriod())
-                                .totalGoalDay(challenge.getTotalGoalDay())
-                                .joinPoint(challenge.getJoinPoint())
-                                .attendeeCount(challenge.getAttendeeCount())
-                                .likeCount(challenge.getCountLikes())
-                                .infoImageUrls(infoImageUrls)
-                                .certImageUrls(certImageUrls)
-                                .challengeNotes(challengeNotes)
-                                .build();
-        }
+        return ChallengeDetailResDTO.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getTitle())
+                .description(challenge.getDetails())
+                .category(challenge.getCategory())
+                .startDate(challenge.getStartDate())
+                .finishDate(challenge.getFinishDate())
+                .period(challenge.getPeriod())
+                .totalGoalDay(challenge.getTotalGoalDay())
+                .joinPoint(challenge.getJoinPoint())
+                .attendeeCount(challenge.getAttendeeCount())
+                .likeCount(challenge.getCountLikes())
+                .infoImageUrls(infoImageUrls)
+                .certImageUrls(certImageUrls)
+                .challengeNotes(challengeNotes)
+                .isJoinable(isJoinable)
+                .status(status)
+                .progress(progress)
+                .build();
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -79,8 +79,7 @@ public class ChallengeAssembler {
     }
 
     public static ChallengeDetailResDTO toChallengeDetailResDTO(
-            Challenge challenge, boolean isJoinable, ChallengeStatus status, Float progress
-    ) {
+            Challenge challenge, boolean isJoinable, ChallengeStatus status, Float progress) {
         List<String> infoImageUrls = challenge.getInfoImages().stream()
                 .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
                 .map(image -> image.getImageUrl())

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Component;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 
 @Slf4j
 @Component
@@ -59,12 +60,12 @@ public class ChallengeAssembler {
                                 .build();
         }
 
-        public static ChallengeListResponseDTO toChallengeListResponseDTO(Challenge challenge) {
+        public static ChallengeListResDTO toChallengeListResDTO(Challenge challenge) {
                 String imageUrl = null;
                 if (!challenge.getInfoImages().isEmpty()) {
                         imageUrl = challenge.getInfoImages().get(0).getImageUrl();
                 }
-                return ChallengeListResponseDTO.builder()
+                return ChallengeListResDTO.builder()
                                 .id(challenge.getId())
                                 .title(challenge.getTitle())
                                 .category(challenge.getCategory())
@@ -73,6 +74,40 @@ public class ChallengeAssembler {
                                 .likeCount(challenge.getCountLikes())
                                 .imageUrl(imageUrl)
                                 .description(challenge.getDetails())
+                                .build();
+        }
+
+        public static ChallengeDetailResDTO toChallengeDetailResDTO(Challenge challenge) {
+                List<String> infoImageUrls = challenge.getInfoImages().stream()
+                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                                .map(image -> image.getImageUrl())
+                                .toList();
+
+                List<String> certImageUrls = challenge.getCertImages().stream()
+                                .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
+                                .map(image -> image.getImageUrl())
+                                .toList();
+
+                List<String> challengeNotes = challenge.getChallengeNotes().stream()
+                                .map(note -> note.getNote())
+                                .toList();
+
+                return ChallengeDetailResDTO.builder()
+                                .challengeId(challenge.getId())
+                                .title(challenge.getTitle())
+                                .description(challenge.getDetails())
+                                .category(challenge.getCategory())
+                                .status(null) // TODO: ChallengeStatus 매핑 필요시 추가
+                                .startDate(challenge.getStartDate())
+                                .finishDate(challenge.getFinishDate())
+                                .period(challenge.getPeriod())
+                                .totalGoalDay(challenge.getTotalGoalDay())
+                                .joinPoint(challenge.getJoinPoint())
+                                .attendeeCount(challenge.getAttendeeCount())
+                                .likeCount(challenge.getCountLikes())
+                                .infoImageUrls(infoImageUrls)
+                                .certImageUrls(certImageUrls)
+                                .challengeNotes(challengeNotes)
                                 .build();
         }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListReqDTO.java
@@ -9,7 +9,7 @@ import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
 @Getter
 @Setter
-public class ChallengeListRequestDTO {
+public class ChallengeListReqDTO {
     private Integer page = 0;
     private Integer size = 10;
     private ChallengeSortField sortField = ChallengeSortField.FINISH_DATE;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -26,5 +26,7 @@ public class ChallengeDetailResDTO {
     private List<String> infoImageUrls;
     private List<String> certImageUrls;
     private List<String> challengeNotes;
+    private Boolean isJoinable;
+    private Integer progress;
     // 필요시 참여자 정보 등 추가 가능
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -15,7 +15,6 @@ public class ChallengeDetailResDTO {
     private String title;
     private String description;
     private Category category;
-    private ChallengeStatus status;
     private LocalDate startDate;
     private LocalDate finishDate;
     private ChallengePeriod period;
@@ -27,6 +26,6 @@ public class ChallengeDetailResDTO {
     private List<String> certImageUrls;
     private List<String> challengeNotes;
     private Boolean isJoinable;
-    private Integer progress;
-    // 필요시 참여자 정보 등 추가 가능
+    private ChallengeStatus status;
+    private Float progress;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -1,0 +1,30 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.res;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengePeriod;
+
+@Getter
+@Builder
+public class ChallengeDetailResDTO {
+    private Long challengeId;
+    private String title;
+    private String description;
+    private Category category;
+    private ChallengeStatus status;
+    private LocalDate startDate;
+    private LocalDate finishDate;
+    private ChallengePeriod period;
+    private Integer totalGoalDay;
+    private Integer joinPoint;
+    private Integer attendeeCount;
+    private Integer likeCount;
+    private List<String> infoImageUrls;
+    private List<String> certImageUrls;
+    private List<String> challengeNotes;
+    // 필요시 참여자 정보 등 추가 가능
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResDTO.java
@@ -11,7 +11,7 @@ import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChallengeListResponseDTO {
+public class ChallengeListResDTO {
     private Long id;
     private String title;
     private Category category;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeRepositoryCustom {
-    Optional<Challenge> getChallengeById(Long id);
+    Challenge getChallengeById(Long id);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
@@ -1,7 +1,9 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeRepositoryCustom {
+    Optional<Challenge> getChallengeById(Long id);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -2,9 +2,9 @@ package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 
 public interface ChallengeRepositoryCustom {
-    Page<Challenge> findChallenges(ChallengeListRequestDTO requestDTO, Pageable pageable);
+    Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
@@ -19,7 +19,7 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Challenge> findChallenges(ChallengeListRequestDTO requestDTO, Pageable pageable) {
+    public Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable) {
         QChallenge challenge = QChallenge.challenge;
         BooleanBuilder builder = new BooleanBuilder();
         LocalDate today = LocalDate.now();

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -4,14 +4,17 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 
 public interface ChallengeService {
 
     ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
             List<MultipartFile> infoImages, List<MultipartFile> certImages);
 
-    PageResponseDTO<ChallengeListResponseDTO> getChallengeList(ChallengeListRequestDTO requestDTO);
+    PageResponseDTO<ChallengeListResDTO> getChallengeList(ChallengeListReqDTO requestDTO);
+
+    ChallengeDetailResDTO getChallengeDetail(Long challengeId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -16,5 +16,5 @@ public interface ChallengeService {
 
     PageResponseDTO<ChallengeListResDTO> getChallengeList(ChallengeListReqDTO requestDTO);
 
-    ChallengeDetailResDTO getChallengeDetail(Long challengeId);
+    ChallengeDetailResDTO getChallengeDetail(Long challengeId, Long memberId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -3,11 +3,13 @@ package site.beilsang.beilsang_server_v2.domain.challenge.service;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeNote;
@@ -28,8 +30,8 @@ import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResponseDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -50,6 +52,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final ChallengeNoteRepository challengeNoteRepository;
     private final PointLogRepository pointLogRepository;
     private final S3Service s3Service;
+    private final ChallengeAssembler challengeAssembler;
 
     @Override
     public ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
@@ -175,15 +178,15 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
-    public PageResponseDTO<ChallengeListResponseDTO> getChallengeList(ChallengeListRequestDTO requestDTO) {
+    public PageResponseDTO<ChallengeListResDTO> getChallengeList(ChallengeListReqDTO requestDTO) {
         Pageable pageable = PageRequest.of(
                 requestDTO.getPage() != null ? requestDTO.getPage() : 0,
                 requestDTO.getSize() != null ? requestDTO.getSize() : 10);
         Page<Challenge> page = challengeRepository.findChallenges(requestDTO, pageable);
-        List<ChallengeListResponseDTO> content = page.getContent().stream()
-                .map(ChallengeAssembler::toChallengeListResponseDTO)
+        List<ChallengeListResDTO> content = page.getContent().stream()
+                .map(ChallengeAssembler::toChallengeListResDTO)
                 .collect(Collectors.toList());
-        return PageResponseDTO.<ChallengeListResponseDTO>builder()
+        return PageResponseDTO.<ChallengeListResDTO>builder()
                 .content(content)
                 .page(page.getNumber())
                 .size(page.getSize())
@@ -191,5 +194,14 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .totalPages(page.getTotalPages())
                 .hasNext(page.hasNext())
                 .build();
+    }
+
+    @Override
+    public ChallengeDetailResDTO getChallengeDetail(Long challengeId) {
+        Optional<Challenge> challenge = challengeRepository.getChallengeById(challengeId);
+        if (challenge.isEmpty()) {
+            throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
+        }
+        return ChallengeAssembler.toChallengeDetailResDTO(challenge.get());
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -197,11 +197,30 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
-    public ChallengeDetailResDTO getChallengeDetail(Long challengeId) {
-        Optional<Challenge> challenge = challengeRepository.getChallengeById(challengeId);
-        if (challenge.isEmpty()) {
+    public ChallengeDetailResDTO getChallengeDetail(Long challengeId, Long memberId) {
+        Challenge challenge = challengeRepository.getChallengeById(challengeId);
+        if (challenge == null) {
             throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
         }
-        return ChallengeAssembler.toChallengeDetailResDTO(challenge.get());
+
+        // 참여 가능 여부 판단
+        ChallengeMember challengeMember = challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId);
+        boolean isJoinable = (challengeMember == null) && !challenge.getStartDate().isBefore(LocalDate.now());
+
+        // 챌린지 상태, 진행도 계산
+        Float progress = null;
+        ChallengeStatus status = isJoinable ? ChallengeStatus.NOT_YET : null;
+        if (challengeMember != null) {
+            switch (challengeMember.getChallengeStatus()) {
+                case ONGOING -> {
+                    status = ChallengeStatus.ONGOING;
+                    progress = (float) challengeMember.getSuccessDays() / challenge.getTotalGoalDay();
+                }
+                case SUCCESS -> status = ChallengeStatus.SUCCESS;
+                case FAIL -> status = ChallengeStatus.FAIL;
+            }
+        }
+
+        return ChallengeAssembler.toChallengeDetailResDTO(challenge, isJoinable, status, progress);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -213,6 +213,12 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 챌린지 진행률 계산
         Float progress = getProgress(challenge, challengeMember, status);
 
+        // TODO: 챌린지 종료 && 참여자라면 사용 포인트(usedPoint), 획득 포인트(earnedPoint) 조회 및 응답에 포함
+        // 1. PointLogRepository에서 memberId, challengeId로 포인트 내역 조회
+        // 2. 사용 포인트: challenge.getJoinPoint() 등
+        // 3. 획득 포인트: PointLog에서 CHALLENGE_SUCCESS/FAIL 등으로 합산
+        // 4. ChallengeDetailResDTO에 필드 추가 및 매핑
+
         return ChallengeAssembler.toChallengeDetailResDTO(challenge, isJoinable, status, progress);
     }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -56,7 +56,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public ChallengeResDTO createChallenge(Long memberId, CreateChallengeReqDTO createChallengeReqDTO,
-            List<MultipartFile> infoImages, List<MultipartFile> certImages) {
+                                           List<MultipartFile> infoImages, List<MultipartFile> certImages) {
         // 이미지 파일 검증
         validateImages(infoImages, certImages);
 
@@ -205,22 +205,38 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         // 참여 가능 여부 판단
         ChallengeMember challengeMember = challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId);
-        boolean isJoinable = (challengeMember == null) && !challenge.getStartDate().isBefore(LocalDate.now());
+        boolean isJoinable = isJoinable(challenge, challengeMember);
 
-        // 챌린지 상태, 진행도 계산
-        Float progress = null;
-        ChallengeStatus status = isJoinable ? ChallengeStatus.NOT_YET : null;
-        if (challengeMember != null) {
-            switch (challengeMember.getChallengeStatus()) {
-                case ONGOING -> {
-                    status = ChallengeStatus.ONGOING;
-                    progress = (float) challengeMember.getSuccessDays() / challenge.getTotalGoalDay();
-                }
-                case SUCCESS -> status = ChallengeStatus.SUCCESS;
-                case FAIL -> status = ChallengeStatus.FAIL;
-            }
-        }
+        // 챌린지 상태
+        ChallengeStatus status = getChallengeStatus(challenge, challengeMember);
+
+        // 챌린지 진행률 계산
+        Float progress = getProgress(challenge, challengeMember, status);
 
         return ChallengeAssembler.toChallengeDetailResDTO(challenge, isJoinable, status, progress);
+    }
+
+    private boolean isJoinable(Challenge challenge, ChallengeMember challengeMember) {
+        LocalDate today = LocalDate.now();
+        if (challengeMember != null) {
+            return false; // 이미 참여 중인 경우는 참여 불가
+        }
+        return !challenge.getFinishDate().isBefore(today); // 챌린지가 이미 종료된 경우 참여 불가
+    }
+
+    private ChallengeStatus getChallengeStatus(Challenge challenge, ChallengeMember challengeMember) {
+        LocalDate today = LocalDate.now();
+        if (challengeMember == null) {
+            return challenge.getStartDate().isAfter(today) ? ChallengeStatus.NOT_YET : ChallengeStatus.ONGOING;
+        } else {
+            return challengeMember.getChallengeStatus();
+        }
+    }
+
+    private Float getProgress(Challenge challenge, ChallengeMember challengeMember, ChallengeStatus status) {
+        if (challengeMember != null && status == ChallengeStatus.ONGOING) {
+            return (float) challengeMember.getSuccessDays() / challenge.getTotalGoalDay();
+        }
+        return null;
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -9,11 +9,14 @@ import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 
 @Repository
 public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
-    //find
+    // find
     List<ChallengeMember> findAllByMemberId(Long memberId);
 
-    //count
+    // count
     Long countByMemberIdAndChallengeStatus(Long memberId, ChallengeStatus challengeStatus);
+
     Long countByMemberId(Long memberId);
 
+    // 챌린지-멤버 단건 조회
+    ChallengeMember findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -28,9 +28,8 @@ public enum BaseResponseCode {
     // challenge
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "C0001", "유효하지 않은 이미지 파일입니다"),
     INVALID_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "C0002", "목표 실천일수가 챌린지 기간을 초과할 수 없습니다"),
-    INVALID_START_DATE(HttpStatus.BAD_REQUEST, "C0003", "시작 날짜는 오늘 이후여야 합니다")
-
-    ;
+    INVALID_START_DATE(HttpStatus.BAD_REQUEST, "C0003", "시작 날짜는 오늘 이후여야 합니다"),
+    NOT_FOUND_CHALLENGE(HttpStatus.BAD_REQUEST, "C0004", "존재하지 않는 챌린지입니다");
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRequestDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.global.config.QueryDslConfig;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
@@ -43,7 +43,7 @@ class ChallengeRepositoryImplTest {
         challengeRepository.save(finished);
         challengeRepository.save(ongoing);
 
-        ChallengeListRequestDTO dto = new ChallengeListRequestDTO();
+        ChallengeListReqDTO dto = new ChallengeListReqDTO();
         dto.setIsFinished(true);
         Pageable pageable = PageRequest.of(0, 10);
 
@@ -74,7 +74,7 @@ class ChallengeRepositoryImplTest {
         challengeRepository.save(finished);
         challengeRepository.save(ongoing);
 
-        ChallengeListRequestDTO dto = new ChallengeListRequestDTO();
+        ChallengeListReqDTO dto = new ChallengeListReqDTO();
         dto.setIsFinished(false);
         Pageable pageable = PageRequest.of(0, 10);
 

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.service;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
-import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeNote;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeNoteRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,7 +64,9 @@ class ChallengeServiceImplTest {
 
     private Member testMember;
     private CreateChallengeReqDTO testCreateChallengeReqDTO;
-    private Challenge testChallenge;
+    private Challenge challenge_NOT_YET;
+    private Challenge challenge_ONGOING;
+    private Challenge challenge_ENDED;
     private MultipartFile testMainImage;
     private MultipartFile testCertImage;
     private List<MultipartFile> testInfoImages;
@@ -84,7 +85,7 @@ class ChallengeServiceImplTest {
         testCreateChallengeReqDTO = createTestChallengeReqDTO();
 
         // 테스트용 챌린지 엔티티 준비 (필수 필드 모두 채움)
-        testChallenge = Challenge.builder()
+        challenge_NOT_YET = Challenge.builder()
                 .id(1L)
                 .title("테스트 챌린지")
                 .category(Category.PLOGGING)
@@ -97,6 +98,45 @@ class ChallengeServiceImplTest {
                 .attendeeCount(1)
                 .countLikes(0)
                 .collectedPoint(100)
+                .infoImages(new ArrayList<>())
+                .certImages(new ArrayList<>())
+                .challengeNotes(new ArrayList<>())
+                .build();
+
+        challenge_ONGOING = Challenge.builder()
+                .id(1L)
+                .title("테스트 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now().minusDays(1))
+                .finishDate(LocalDate.now().plusDays(5))
+                .joinPoint(100)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("테스트 챌린지 설명")
+                .attendeeCount(1)
+                .countLikes(0)
+                .collectedPoint(100)
+                .infoImages(new ArrayList<>())
+                .certImages(new ArrayList<>())
+                .challengeNotes(new ArrayList<>())
+                .build();
+
+        challenge_ENDED = Challenge.builder()
+                .id(1L)
+                .title("테스트 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now().minusDays(5))
+                .finishDate(LocalDate.now().plusDays(1))
+                .joinPoint(100)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("테스트 챌린지 설명")
+                .attendeeCount(1)
+                .countLikes(0)
+                .collectedPoint(100)
+                .infoImages(new ArrayList<>())
+                .certImages(new ArrayList<>())
+                .challengeNotes(new ArrayList<>())
                 .build();
 
         // 테스트용 MultipartFile 준비
@@ -158,7 +198,7 @@ class ChallengeServiceImplTest {
         CreateChallengeReqDTO futureStartReqDTO = createTestChallengeReqDTOWithStartDate(LocalDate.now().plusDays(10));
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
-        when(challengeRepository.save(any(Challenge.class))).thenReturn(testChallenge);
+        when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_NOT_YET);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
@@ -185,7 +225,7 @@ class ChallengeServiceImplTest {
         CreateChallengeReqDTO todayStartReqDTO = createTestChallengeReqDTOWithStartDate(LocalDate.now());
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
-        when(challengeRepository.save(any(Challenge.class))).thenReturn(testChallenge);
+        when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_NOT_YET);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
@@ -218,7 +258,7 @@ class ChallengeServiceImplTest {
                 .build();
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberWithPoint));
-        when(challengeRepository.save(any(Challenge.class))).thenReturn(testChallenge);
+        when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_NOT_YET);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
@@ -232,6 +272,26 @@ class ChallengeServiceImplTest {
         // then
         assertThat(memberWithPoint.getPoint()).isEqualTo(initialPoint - joinPoint);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class), any(MultipartFile.class));
+    }
+
+    @Test
+    @DisplayName("참여하지 않은 사용자가 참여 가능한 챌린지 상세 조회")
+    void getChallengeDetail_NotJoinedAndJoinable() {
+        // given
+        Long memberId = 2L; // 테스트 멤버(참여하지 않은 사용자)
+        Long challengeId = 1L;
+
+        when(challengeRepository.getChallengeById(challengeId)).thenReturn(challenge_ONGOING);
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(null);
+
+        // when
+        var result = challengeService.getChallengeDetail(challengeId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getIsJoinable()).isTrue();
+        assertThat(result.getStatus()).isEqualTo(ChallengeStatus.ONGOING);
+        assertThat(result.getProgress()).isNull();
     }
 
     // 테스트 데이터 생성 헬퍼 메서드들


### PR DESCRIPTION
## 📌 이슈 번호
closed #20

## 🍬 기능 설명

- 챌린지 상세 조회 API 구현 (`GET /challenge/{challengeId}`)
  - 챌린지 ID로 상세 정보(제목, 설명, 카테고리, 상태, 이미지, 노트, 참여자 수, 좋아요 수 등) 반환
  - 로그인 사용자의 참여 여부, 진행도, 참여 가능 여부, 상태(ONGOING/NOT_YET 등) 동적 응답
- 챌린지에 참여했고 종료된 경우, 사용 포인트/획득 포인트(추후 PointLog 연관관계 확장 필요 #24) 응답 설계
- BaseResponse로 일관된 응답 포맷 적용
- 예외처리(존재하지 않는 챌린지 등)

## 🤔 코드 리뷰에서 집중적으로 볼 내용

- ChallengeServiceImpl의 참여/진행도/상태/참여가능 여부 판단 로직
- PointLog와 Challenge 연관관계 설계 방향(추후 확장성)
- 테스트 케이스별 시나리오(참여/미참여, 진행중/종료 등) 분기 처리

## ⭐ 기타 사항

- PointLog의 챌린지 연관관계는 nullable로 설계(다양한 포인트 이벤트 확장성 고려)
- [참고] 실무에서의 포인트 로그 설계/확장 패턴, 단일 테이블 관리 등