### PR TITLE
[Feat] 포인트로그 엔티티 수정 및 내역 추적 기능 추가

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -79,7 +79,9 @@ public class ChallengeAssembler {
     }
 
     public static ChallengeDetailResDTO toChallengeDetailResDTO(
-            Challenge challenge, boolean isJoinable, ChallengeStatus status, Float progress) {
+            Challenge challenge, boolean isJoinable, ChallengeStatus status, Float progress,
+            Integer usedPoint, Integer earnedPoint
+    ) {
         List<String> infoImageUrls = challenge.getInfoImages().stream()
                 .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
                 .map(image -> image.getImageUrl())
@@ -112,6 +114,8 @@ public class ChallengeAssembler {
                 .isJoinable(isJoinable)
                 .status(status)
                 .progress(progress)
+                .usedPoint(usedPoint)
+                .earnedPoint(earnedPoint)
                 .build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -28,4 +28,6 @@ public class ChallengeDetailResDTO {
     private Boolean isJoinable;
     private ChallengeStatus status;
     private Float progress;
+    private Integer usedPoint;
+    private Integer earnedPoint;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -78,17 +78,18 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (member.getPoint() < joinPoint) {
             throw new BaseException(BaseResponseCode.NOT_ENOUGH_POINT);
         }
+        // 챌린지 생성
+        Challenge challenge = challengeRepository.save(
+                ChallengeAssembler.toEntity(createChallengeReqDTO));
+
         pointLogRepository.save(PointLog.builder()
                 .pointName(PointName.JOIN_CHALLENGE)
                 .status(PointStatus.USE)
                 .value(joinPoint)
                 .member(member)
+                .challenge(challenge)
                 .build());
         member.subPoint(joinPoint); // 포인트 차감
-
-        // 챌린지 생성
-        Challenge challenge = challengeRepository.save(
-                ChallengeAssembler.toEntity(createChallengeReqDTO));
 
         // 챌린지 정보 이미지들 업로드 및 저장
         saveInfoImages(challenge, infoImages);
@@ -213,13 +214,24 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 챌린지 진행률 계산
         Float progress = getProgress(challenge, challengeMember, status);
 
-        // TODO: 챌린지 종료 && 참여자라면 사용 포인트(usedPoint), 획득 포인트(earnedPoint) 조회 및 응답에 포함
-        // 1. PointLogRepository에서 memberId, challengeId로 포인트 내역 조회
-        // 2. 사용 포인트: challenge.getJoinPoint() 등
-        // 3. 획득 포인트: PointLog에서 CHALLENGE_SUCCESS/FAIL 등으로 합산
-        // 4. ChallengeDetailResDTO에 필드 추가 및 매핑
+        // 챌린지 종료 && 참여자라면 사용 포인트(usedPoint), 획득 포인트(earnedPoint) 조회 및 응답에 포함
+        Integer usedPoint = null;
+        Integer earnedPoint = null;
+        
+        if (challengeMember != null && (status == ChallengeStatus.SUCCESS || status == ChallengeStatus.FAIL)) {
+            // 사용 포인트: 해당 챌린지 참여 시 사용한 포인트 조회
+            List<PointLog> pointLogs = pointLogRepository.findByMemberIdAndChallengeId(
+                    memberId, challengeId
+            );
+            usedPoint = pointLogs.stream().filter(pointLog -> pointLog.getStatus() == PointStatus.USE)
+                    .mapToInt(PointLog::getValue).sum();
+            earnedPoint = pointLogs.stream().filter(pointLog -> pointLog.getStatus() == PointStatus.EARN)
+                    .mapToInt(PointLog::getValue).sum();
+        }
 
-        return ChallengeAssembler.toChallengeDetailResDTO(challenge, isJoinable, status, progress);
+        return ChallengeAssembler.toChallengeDetailResDTO(
+                challenge, isJoinable, status, progress, usedPoint, earnedPoint
+        );
     }
 
     private boolean isJoinable(Challenge challenge, ChallengeMember challengeMember) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/entity/PointLog.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/entity/PointLog.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
@@ -34,4 +35,8 @@ public class PointLog extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/repository/PointLogRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/repository/PointLogRepository.java
@@ -2,9 +2,14 @@ package site.beilsang.beilsang_server_v2.domain.point.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.point.entity.PointLog;
+import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 
 import java.util.List;
 
 public interface PointLogRepository extends JpaRepository<PointLog, Long> {
     List<PointLog> findAllByMemberId(Long memberId);
+    
+    List<PointLog> findByMemberIdAndChallengeId(Long memberId, Long challengeId);
+    
+    List<PointLog> findByMemberIdAndChallengeIdAndStatus(Long memberId, Long challengeId, PointStatus status);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/repository/PointLogRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/repository/PointLogRepository.java
@@ -2,7 +2,6 @@ package site.beilsang.beilsang_server_v2.domain.point.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.point.entity.PointLog;
-import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 
 import java.util.List;
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/repository/PointLogRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/repository/PointLogRepository.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 public interface PointLogRepository extends JpaRepository<PointLog, Long> {
     List<PointLog> findAllByMemberId(Long memberId);
-    
+
     List<PointLog> findByMemberIdAndChallengeId(Long memberId, Long challengeId);
-    
-    List<PointLog> findByMemberIdAndChallengeIdAndStatus(Long memberId, Long challengeId, PointStatus status);
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
closed #24 

## 🍬 기능 설명
- PointLog 엔티티에 Challenge 연관관계를 추가하여 챌린지 관련 포인트 내역을 명확히 추적할 수 있도록 구현
- 챌린지 종료 시 사용자가 해당 챌린지에서 사용/획득한 포인트 정보를 상세 조회 응답에 포함
- 기존 PointLog 데이터와의 호환성을 위해 Challenge 연관관계를 nullable로 설계

## 🤔 코드 리뷰에서 집중적으로 볼 내용
<!-- 코드를 작성하면서 헷갈렸던 부분을 캡처/복사해서 넣자 -->
 1. PointLog 엔티티 연관관계 추가

 ```java
  @ManyToOne(fetch = FetchType.LAZY)
  @JoinColumn(name = "challenge_id")
  private Challenge challenge;
```
  - Challenge와의 ManyToOne 관계를 nullable로 설정하여 기존 데이터 호환성 유지
     기존 데이터 직접 수정 필요
  - LAZY 로딩

  3. Repository 쿼리 메서드

```java
  List<PointLog> findByMemberIdAndChallengeId(Long memberId, Long challengeId);
```
  - Spring Data JPA 메서드 네이밍 컨벤션 사용으로 간결한 구현
  - @Query 어노테이션 대신 자동 쿼리 생성 활용

  4. 포인트 로직 수정 순서

```java
  // 챌린지 생성 먼저 수행
  Challenge challenge = challengeRepository.save(
          ChallengeAssembler.toEntity(createChallengeReqDTO));

  // 그 다음 PointLog에 Challenge 연관관계 저장
  pointLogRepository.save(PointLog.builder()
          .pointName(PointName.JOIN_CHALLENGE)
          .status(PointStatus.USE)
          .value(joinPoint)
          .member(member)
          .challenge(challenge)  // 추가된 부분
          .build());
```
  - Challenge 엔티티를 먼저 저장한 후 PointLog에 연관관계 설정하는 순서가 중요

  5. 챌린지 상세 조회 시 포인트 정보 조회

```java
  if (challengeMember != null && (status == ChallengeStatus.SUCCESS || status ==
  ChallengeStatus.FAIL)) {
      List<PointLog> pointLogs = pointLogRepository.findByMemberIdAndChallengeId(
              memberId, challengeId);
      usedPoint = pointLogs.stream().filter(pointLog -> pointLog.getStatus() == PointStatus.USE)
              .mapToInt(PointLog::getValue).sum();
      earnedPoint = pointLogs.stream().filter(pointLog -> pointLog.getStatus() ==
  PointStatus.EARN)
              .mapToInt(PointLog::getValue).sum();
  }
```
  - 챌린지 종료 상태(SUCCESS/FAIL)이고 참여자인 경우만 포인트 정보 조회
  - Stream API로 사용/획득 포인트 분리하여 합산

## ⭐ 기타 사항
<!-- 개발할 때 참고했던 레퍼런스나 공유하면 좋을 것들을 나눠보아요 -->

  - 기존 데이터 영향: challenge_id 컬럼이 nullable로 추가되어 기존 PointLog 데이터는 null 값
  유지
  - 향후 다양한 포인트 이벤트(출석, 미션 등) 추가 시 동일한 패턴으로 확장 가능
  - 챌린지 종료된 참여자에게만 포인트 조회 로직 실행하여 불필요한 DB 조회 방지