### PR TITLE
[Refac] 챌린지 상태 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### DS_Store ###
 .DS_Store
+
+### Claude Code ###
+CLAUDE.md

--- a/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class BeilsangServerV2Application {
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -9,17 +9,28 @@ import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+
+import java.time.LocalDate;
 
 @Slf4j
 @Component
 public class ChallengeAssembler {
 
     public static Challenge toEntity(CreateChallengeReqDTO request) {
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = request.getStartDate();
+        
+        // 초기 상태 결정
+        ChallengeStatus initialStatus = today.isBefore(startDate) ? 
+            ChallengeStatus.NOT_YET : ChallengeStatus.IN_PROGRESS;
+            
         return Challenge.builder()
                 .category(request.getCategory())
+                .status(initialStatus)
                 .title(request.getTitle())
-                .startDate(request.getStartDate())
-                .finishDate(request.getStartDate().plusDays(request.getPeriod().getDays() - 1))
+                .startDate(startDate)
+                .finishDate(startDate.plusDays(request.getPeriod().getDays() - 1))
                 .joinPoint(request.getJoinPoint())
                 .details(request.getDetails())
                 .period(request.getPeriod())

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -8,7 +8,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Slf4j
 @Component
@@ -70,7 +70,7 @@ public class ChallengeAssembler {
                 .id(challenge.getId())
                 .title(challenge.getTitle())
                 .category(challenge.getCategory())
-                .status(null) // TODO: ChallengeStatus 추가
+                .status(null) // TODO: ChallengeMemberStatus 추가
                 .participantCount(challenge.getAttendeeCount())
                 .likeCount(challenge.getCountLikes())
                 .imageUrl(imageUrl)
@@ -79,7 +79,7 @@ public class ChallengeAssembler {
     }
 
     public static ChallengeDetailResDTO toChallengeDetailResDTO(
-            Challenge challenge, boolean isJoinable, ChallengeStatus status, Float progress,
+            Challenge challenge, boolean isJoinable, ChallengeMemberStatus status, Float progress,
             Integer usedPoint, Integer earnedPoint
     ) {
         List<String> infoImageUrls = challenge.getInfoImages().stream()

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListReqDTO.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeSortField;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
@@ -15,7 +16,8 @@ public class ChallengeListReqDTO {
     private ChallengeSortField sortField = ChallengeSortField.FINISH_DATE;
     private SortDirection sortDirection = SortDirection.DESC;
     private Category category;
-    private ChallengeMemberStatus status;
+    private ChallengeMemberStatus challengeMemberStatus;
+    private ChallengeStatus challengeStatus;
     private String keyword;
     private Boolean isFinished;
     private Boolean isJoined;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ChallengeListReqDTO.java
@@ -3,7 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeSortField;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
@@ -15,7 +15,7 @@ public class ChallengeListReqDTO {
     private ChallengeSortField sortField = ChallengeSortField.FINISH_DATE;
     private SortDirection sortDirection = SortDirection.DESC;
     private Category category;
-    private ChallengeStatus status;
+    private ChallengeMemberStatus status;
     private String keyword;
     private Boolean isFinished;
     private Boolean isJoined;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengePeriod;
 
 @Getter
@@ -26,7 +26,7 @@ public class ChallengeDetailResDTO {
     private List<String> certImageUrls;
     private List<String> challengeNotes;
     private Boolean isJoinable;
-    private ChallengeStatus status;
+    private ChallengeMemberStatus status;
     private Float progress;
     private Integer usedPoint;
     private Integer earnedPoint;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeListResDTO.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Getter
 @Builder
@@ -15,7 +15,7 @@ public class ChallengeListResDTO {
     private Long id;
     private String title;
     private Category category;
-    private ChallengeStatus status;
+    private ChallengeMemberStatus status;
     private int participantCount;
     private int likeCount;
     private String imageUrl;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -11,6 +11,7 @@ import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
 import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengePeriod;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -29,6 +30,9 @@ public class Challenge extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Category category;
+
+    @Enumerated(EnumType.STRING)
+    private ChallengeStatus status;
 
     private String title;
 
@@ -68,4 +72,18 @@ public class Challenge extends BaseEntity {
     private Integer countLikes = 0;
 
     private Integer collectedPoint;
+
+    public void updateStatus(ChallengeStatus status) {
+        this.status = status;
+    }
+
+    public ChallengeStatus calculateCurrentStatus(LocalDate today) {
+        if (today.isBefore(startDate)) {
+            return ChallengeStatus.NOT_YET;
+        } else if (today.isAfter(finishDate)) {
+            return ChallengeStatus.END;
+        } else {
+            return ChallengeStatus.IN_PROGRESS;
+        }
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -2,6 +2,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -11,7 +12,6 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRe
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
-import java.time.LocalDate;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -22,58 +22,89 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
     public Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable) {
         QChallenge challenge = QChallenge.challenge;
         BooleanBuilder builder = new BooleanBuilder();
-        LocalDate today = LocalDate.now();
 
-        // 카테고리 필터링
-        if (requestDTO.getCategory() != null) {
-            builder.and(challenge.category.eq(requestDTO.getCategory()));
-        }
-        // isFinished 필터링
-        if (requestDTO.getIsFinished() != null) {
-            if (requestDTO.getIsFinished()) {
-                builder.and(challenge.finishDate.lt(today));
-            } else {
-                builder.and(challenge.finishDate.goe(today));
-            }
-        }
-        // isJoined 필터링
-        if (requestDTO.getIsJoined() != null && requestDTO.getMemberId() != null) {
-            if (requestDTO.getIsJoined()) {
-                builder.and(challenge.challengeMembers.any().member.id.eq(requestDTO.getMemberId()));
-            } else {
-                builder.and(challenge.challengeMembers.any().member.id.ne(requestDTO.getMemberId()));
-            }
-        }
+        // 필터링 조건 추가
+        addCategoryFilter(builder, challenge, requestDTO);
+        addKeywordFilter(builder, challenge, requestDTO);
+        addChallengeStatusFilter(builder, challenge, requestDTO);
+        addMembershipFilter(builder, challenge, requestDTO);
 
-        // 기본 쿼리
-        var query = queryFactory.selectFrom(challenge)
-                .where(builder);
+        // 쿼리 실행
+        var query = queryFactory.selectFrom(challenge).where(builder);
+        applySorting(query, challenge, requestDTO);
 
-        // 정렬 처리
-        if (requestDTO.getSortField() != null && requestDTO.getSortDirection() != null) {
-            boolean asc = SortDirection.ASC == requestDTO
-                    .getSortDirection();
-            switch (requestDTO.getSortField()) {
-                case ATTENDEE_COUNT -> query.orderBy(asc ? challenge.attendeeCount.asc() : challenge.attendeeCount.desc());
-                case COUNT_LIKES -> query.orderBy(asc ? challenge.countLikes.asc() : challenge.countLikes.desc());
-                case START_DATE -> query.orderBy(asc ? challenge.startDate.asc() : challenge.startDate.desc());
-                case FINISH_DATE -> query.orderBy(asc ? challenge.finishDate.asc() : challenge.finishDate.desc());
-            }
-        }
-
-        // 페이징
         List<Challenge> content = query
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        // 전체 개수 쿼리
-        long total = queryFactory
+        long total = countTotal(challenge, builder);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private void addCategoryFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO) {
+        if (requestDTO.getCategory() != null) {
+            builder.and(challenge.category.eq(requestDTO.getCategory()));
+        }
+    }
+
+    private void addKeywordFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO) {
+        if (requestDTO.getKeyword() != null && !requestDTO.getKeyword().trim().isEmpty()) {
+            String keyword = "%" + requestDTO.getKeyword().trim() + "%";
+            builder.and(
+                challenge.title.likeIgnoreCase(keyword)
+                .or(challenge.details.likeIgnoreCase(keyword))
+            );
+        }
+    }
+
+    private void addChallengeStatusFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO) {
+        if (requestDTO.getChallengeStatus() != null) {
+            builder.and(challenge.status.eq(requestDTO.getChallengeStatus()));
+        }
+    }
+
+    private void addMembershipFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO) {
+        if (requestDTO.getMemberId() == null) return;
+
+        // 멤버의 참여 상태별 필터링 (SUCCESS, FAIL, ONGOING, NOT_YET)
+        if (requestDTO.getChallengeMemberStatus() != null) {
+            builder.and(
+                challenge.challengeMembers.any()
+                    .member.id.eq(requestDTO.getMemberId())
+                    .and(challenge.challengeMembers.any().challengeMemberStatus.eq(requestDTO.getChallengeMemberStatus()))
+            );
+        }
+
+        // 참여/미참여 필터링
+        if (requestDTO.getIsJoined() != null) {
+            if (requestDTO.getIsJoined()) {
+                builder.and(challenge.challengeMembers.any().member.id.eq(requestDTO.getMemberId()));
+            } else {
+                builder.and(challenge.challengeMembers.any().member.id.eq(requestDTO.getMemberId()).not());
+            }
+        }
+    }
+
+    private void applySorting(JPAQuery<Challenge> query, QChallenge challenge, ChallengeListReqDTO requestDTO) {
+        if (requestDTO.getSortField() == null || requestDTO.getSortDirection() == null) return;
+
+        boolean asc = SortDirection.ASC == requestDTO.getSortDirection();
+        switch (requestDTO.getSortField()) {
+            case ATTENDEE_COUNT -> query.orderBy(asc ? challenge.attendeeCount.asc() : challenge.attendeeCount.desc());
+            case COUNT_LIKES -> query.orderBy(asc ? challenge.countLikes.asc() : challenge.countLikes.desc());
+            case START_DATE -> query.orderBy(asc ? challenge.startDate.asc() : challenge.startDate.desc());
+            case FINISH_DATE -> query.orderBy(asc ? challenge.finishDate.asc() : challenge.finishDate.desc());
+        }
+    }
+
+    private long countTotal(QChallenge challenge, BooleanBuilder builder) {
+        Long count = queryFactory
                 .select(Wildcard.count)
                 .from(challenge)
                 .where(builder)
                 .fetchOne();
-
-        return new PageImpl<>(content, pageable, total);
+        return count != null ? count : 0L;
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.service;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,6 +27,7 @@ import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
@@ -104,11 +106,9 @@ public class ChallengeServiceImpl implements ChallengeService {
                         .build())
                 .toList());
 
-        // ChallengeMemberStatus 상태 결정
-        ChallengeMemberStatus challengeMemberStatus = ChallengeMemberStatus.ONGOING;
-        if (createChallengeReqDTO.getStartDate().isAfter(LocalDate.now())) {
-            challengeMemberStatus = ChallengeMemberStatus.NOT_YET;
-        }
+        // ChallengeMemberStatus 상태 결정 - Challenge의 현재 상태를 기반으로 결정
+        ChallengeMemberStatus challengeMemberStatus = challenge.getStatus() == ChallengeStatus.NOT_YET ? 
+            ChallengeMemberStatus.NOT_YET : ChallengeMemberStatus.ONGOING;
 
         // ChallengeMember 생성
         challengeMemberRepository.save(ChallengeMember.builder()
@@ -203,29 +203,39 @@ public class ChallengeServiceImpl implements ChallengeService {
             throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
         }
 
+        Optional<ChallengeMember> challengeMemberOpt = challengeMemberRepository.findByChallengeIdAndMemberId(
+                challengeId, memberId);
+        
         // 참여 가능 여부 판단
-        ChallengeMember challengeMember = challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId);
-        boolean isJoinable = isJoinable(challenge, challengeMember);
-
+        boolean isJoinable = challengeMemberOpt.isEmpty() && challenge.getStatus() != ChallengeStatus.END;
+        
         // 챌린지 상태
-        ChallengeMemberStatus status = getChallengeStatus(challenge, challengeMember);
+        ChallengeMemberStatus status = challengeMemberOpt
+                .map(ChallengeMember::getChallengeMemberStatus)
+                .orElse(ChallengeMemberStatus.NOT_JOINED);
 
         // 챌린지 진행률 계산
-        Float progress = getProgress(challenge, challengeMember, status);
+        Float progress = challengeMemberOpt
+                .filter(member -> status == ChallengeMemberStatus.ONGOING)
+                .map(member -> (float) member.getSuccessDays() / challenge.getTotalGoalDay())
+                .orElse(null);
 
-        // 챌린지 종료 && 참여자라면 사용 포인트(usedPoint), 획득 포인트(earnedPoint) 조회 및 응답에 포함
+        // 챌린지 종료 && 참여자라면 사용 포인트(usedPoint), 획득 포인트(earnedPoint) 조회
         Integer usedPoint = null;
         Integer earnedPoint = null;
         
-        if (challengeMember != null && (status == ChallengeMemberStatus.SUCCESS || status == ChallengeMemberStatus.FAIL)) {
-            // 사용 포인트: 해당 챌린지 참여 시 사용한 포인트 조회
-            List<PointLog> pointLogs = pointLogRepository.findByMemberIdAndChallengeId(
-                    memberId, challengeId
-            );
-            usedPoint = pointLogs.stream().filter(pointLog -> pointLog.getStatus() == PointStatus.USE)
-                    .mapToInt(PointLog::getValue).sum();
-            earnedPoint = pointLogs.stream().filter(pointLog -> pointLog.getStatus() == PointStatus.EARN)
-                    .mapToInt(PointLog::getValue).sum();
+        if (challengeMemberOpt.isPresent() && (status == ChallengeMemberStatus.SUCCESS || status == ChallengeMemberStatus.FAIL)) {
+            List<PointLog> pointLogs = pointLogRepository.findByMemberIdAndChallengeId(memberId, challengeId);
+
+            usedPoint = pointLogs.stream()
+                    .filter(pointLog -> pointLog.getStatus() == PointStatus.USE)
+                    .mapToInt(PointLog::getValue)
+                    .sum();
+
+            earnedPoint = pointLogs.stream()
+                    .filter(pointLog -> pointLog.getStatus() == PointStatus.EARN)
+                    .mapToInt(PointLog::getValue)
+                    .sum();
         }
 
         return ChallengeAssembler.toChallengeDetailResDTO(
@@ -233,27 +243,4 @@ public class ChallengeServiceImpl implements ChallengeService {
         );
     }
 
-    private boolean isJoinable(Challenge challenge, ChallengeMember challengeMember) {
-        LocalDate today = LocalDate.now();
-        if (challengeMember != null) {
-            return false; // 이미 참여 중인 경우는 참여 불가
-        }
-        return !challenge.getFinishDate().isBefore(today); // 챌린지가 이미 종료된 경우 참여 불가
-    }
-
-    private ChallengeMemberStatus getChallengeStatus(Challenge challenge, ChallengeMember challengeMember) {
-        LocalDate today = LocalDate.now();
-        if (challengeMember == null) {
-            return challenge.getStartDate().isAfter(today) ? ChallengeMemberStatus.NOT_YET : ChallengeMemberStatus.ONGOING;
-        } else {
-            return challengeMember.getChallengeMemberStatus();
-        }
-    }
-
-    private Float getProgress(Challenge challenge, ChallengeMember challengeMember, ChallengeMemberStatus status) {
-        if (challengeMember != null && status == ChallengeMemberStatus.ONGOING) {
-            return (float) challengeMember.getSuccessDays() / challenge.getTotalGoalDay();
-        }
-        return null;
-    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -3,7 +3,6 @@ package site.beilsang.beilsang_server_v2.domain.challenge.service;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,7 +25,7 @@ import site.beilsang.beilsang_server_v2.domain.point.repository.PointLogReposito
 import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointName;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
@@ -105,17 +104,17 @@ public class ChallengeServiceImpl implements ChallengeService {
                         .build())
                 .toList());
 
-        // ChallengeStatus 상태 결정
-        ChallengeStatus challengeStatus = ChallengeStatus.ONGOING;
+        // ChallengeMemberStatus 상태 결정
+        ChallengeMemberStatus challengeMemberStatus = ChallengeMemberStatus.ONGOING;
         if (createChallengeReqDTO.getStartDate().isAfter(LocalDate.now())) {
-            challengeStatus = ChallengeStatus.NOT_YET;
+            challengeMemberStatus = ChallengeMemberStatus.NOT_YET;
         }
 
         // ChallengeMember 생성
         challengeMemberRepository.save(ChallengeMember.builder()
                 .isHost(true)
                 .successDays(0)
-                .challengeStatus(challengeStatus)
+                .challengeMemberStatus(challengeMemberStatus)
                 .isFeedUpload(false)
                 .member(member)
                 .challenge(challenge)
@@ -209,7 +208,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         boolean isJoinable = isJoinable(challenge, challengeMember);
 
         // 챌린지 상태
-        ChallengeStatus status = getChallengeStatus(challenge, challengeMember);
+        ChallengeMemberStatus status = getChallengeStatus(challenge, challengeMember);
 
         // 챌린지 진행률 계산
         Float progress = getProgress(challenge, challengeMember, status);
@@ -218,7 +217,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         Integer usedPoint = null;
         Integer earnedPoint = null;
         
-        if (challengeMember != null && (status == ChallengeStatus.SUCCESS || status == ChallengeStatus.FAIL)) {
+        if (challengeMember != null && (status == ChallengeMemberStatus.SUCCESS || status == ChallengeMemberStatus.FAIL)) {
             // 사용 포인트: 해당 챌린지 참여 시 사용한 포인트 조회
             List<PointLog> pointLogs = pointLogRepository.findByMemberIdAndChallengeId(
                     memberId, challengeId
@@ -242,17 +241,17 @@ public class ChallengeServiceImpl implements ChallengeService {
         return !challenge.getFinishDate().isBefore(today); // 챌린지가 이미 종료된 경우 참여 불가
     }
 
-    private ChallengeStatus getChallengeStatus(Challenge challenge, ChallengeMember challengeMember) {
+    private ChallengeMemberStatus getChallengeStatus(Challenge challenge, ChallengeMember challengeMember) {
         LocalDate today = LocalDate.now();
         if (challengeMember == null) {
-            return challenge.getStartDate().isAfter(today) ? ChallengeStatus.NOT_YET : ChallengeStatus.ONGOING;
+            return challenge.getStartDate().isAfter(today) ? ChallengeMemberStatus.NOT_YET : ChallengeMemberStatus.ONGOING;
         } else {
-            return challengeMember.getChallengeStatus();
+            return challengeMember.getChallengeMemberStatus();
         }
     }
 
-    private Float getProgress(Challenge challenge, ChallengeMember challengeMember, ChallengeStatus status) {
-        if (challengeMember != null && status == ChallengeStatus.ONGOING) {
+    private Float getProgress(Challenge challenge, ChallengeMember challengeMember, ChallengeMemberStatus status) {
+        if (challengeMember != null && status == ChallengeMemberStatus.ONGOING) {
             return (float) challengeMember.getSuccessDays() / challenge.getTotalGoalDay();
         }
         return null;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -220,22 +220,14 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .map(member -> (float) member.getSuccessDays() / challenge.getTotalGoalDay())
                 .orElse(null);
 
-        // 챌린지 종료 && 참여자라면 사용 포인트(usedPoint), 획득 포인트(earnedPoint) 조회
+        // 포인트 정보 계산
         Integer usedPoint = null;
         Integer earnedPoint = null;
         
         if (challengeMemberOpt.isPresent() && (status == ChallengeMemberStatus.SUCCESS || status == ChallengeMemberStatus.FAIL)) {
             List<PointLog> pointLogs = pointLogRepository.findByMemberIdAndChallengeId(memberId, challengeId);
-
-            usedPoint = pointLogs.stream()
-                    .filter(pointLog -> pointLog.getStatus() == PointStatus.USE)
-                    .mapToInt(PointLog::getValue)
-                    .sum();
-
-            earnedPoint = pointLogs.stream()
-                    .filter(pointLog -> pointLog.getStatus() == PointStatus.EARN)
-                    .mapToInt(PointLog::getValue)
-                    .sum();
+            usedPoint = calculatePointSum(pointLogs, PointStatus.USE);
+            earnedPoint = calculatePointSum(pointLogs, PointStatus.EARN);
         }
 
         return ChallengeAssembler.toChallengeDetailResDTO(
@@ -243,4 +235,10 @@ public class ChallengeServiceImpl implements ChallengeService {
         );
     }
 
+    private Integer calculatePointSum(List<PointLog> pointLogs, PointStatus targetStatus) {
+        return pointLogs.stream()
+                .filter(pointLog -> pointLog.getStatus() == targetStatus)
+                .mapToInt(PointLog::getValue)
+                .sum();
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeStatusScheduler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeStatusScheduler.java
@@ -1,0 +1,49 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChallengeStatusScheduler {
+
+    private final ChallengeRepository challengeRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    public void updateChallengeStatuses() {
+        log.info("챌린지 상태 업데이트 스케줄러 실행 시작");
+        
+        LocalDate today = LocalDate.now();
+        
+        // 모든 챌린지 조회
+        List<Challenge> challenges = challengeRepository.findAll();
+        
+        int updatedCount = 0;
+        
+        for (Challenge challenge : challenges) {
+            ChallengeStatus currentStatus = challenge.getStatus();
+            ChallengeStatus calculatedStatus = challenge.calculateCurrentStatus(today);
+            
+            // 상태가 변경된 경우에만 업데이트
+            if (currentStatus != calculatedStatus) {
+                challenge.updateStatus(calculatedStatus);
+                updatedCount++;
+                log.debug("챌린지 ID: {}, 상태 변경: {} -> {}", 
+                    challenge.getId(), currentStatus, calculatedStatus);
+            }
+        }
+        
+        log.info("챌린지 상태 업데이트 완료. 총 {}개 챌린지 상태 변경", updatedCount);
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
 import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +29,7 @@ public class ChallengeMember extends BaseEntity {
     private Integer successDays;
 
     @Enumerated(EnumType.STRING)
-    private ChallengeStatus challengeStatus;
+    private ChallengeMemberStatus challengeMemberStatus;
 
     private Boolean isFeedUpload;
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -2,6 +2,7 @@ package site.beilsang.beilsang_server_v2.domain.member.repository;
 
 import java.util.List;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
@@ -18,5 +19,5 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
     Long countByMemberId(Long memberId);
 
     // 챌린지-멤버 단건 조회
-    ChallengeMember findByChallengeIdAndMemberId(Long challengeId, Long memberId);
+    Optional<ChallengeMember> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -13,7 +13,7 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
     List<ChallengeMember> findAllByMemberId(Long memberId);
 
     // count
-    Long countByMemberIdAndChallengeStatus(Long memberId, ChallengeMemberStatus challengeMemberStatus);
+    Long countByMemberIdAndChallengeMemberStatus(Long memberId, ChallengeMemberStatus challengeMemberStatus);
 
     Long countByMemberId(Long memberId);
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 @Repository
 public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
@@ -13,7 +13,7 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
     List<ChallengeMember> findAllByMemberId(Long memberId);
 
     // count
-    Long countByMemberIdAndChallengeStatus(Long memberId, ChallengeStatus challengeStatus);
+    Long countByMemberIdAndChallengeStatus(Long memberId, ChallengeMemberStatus challengeMemberStatus);
 
     Long countByMemberId(Long memberId);
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
@@ -23,7 +23,7 @@ import site.beilsang.beilsang_server_v2.domain.uuid.entity.Uuid;
 import site.beilsang.beilsang_server_v2.domain.uuid.repository.UuidRepository;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -55,13 +55,13 @@ public class MemberService {
         Long countFeed = feedRepository.countByChallengeMember_IdIn(challengeMemberIds);
 
         //달성한 챌린지 개수
-        Long countSuccessChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeStatus.SUCCESS);
+        Long countSuccessChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeMemberStatus.SUCCESS);
 
         // 챌린지 개수 : 멤버 아이디로 챌린지멤버 테이블 카운트
         Long countChallenge = challengeMemberRepository.countByMemberId(memberId);
 
         // 실패한 챌린지 개수
-        Long countFailedChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeStatus.FAIL);
+        Long countFailedChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeMemberStatus.FAIL);
 
         // 찜 개수 : 회원 아이디로 챌린지라이크 테이블 접근해서 카운트
         Long countlike = challengeLikeRepository.countByMemberId(memberId);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
@@ -55,13 +55,13 @@ public class MemberService {
         Long countFeed = feedRepository.countByChallengeMember_IdIn(challengeMemberIds);
 
         //달성한 챌린지 개수
-        Long countSuccessChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeMemberStatus.SUCCESS);
+        Long countSuccessChallenge = challengeMemberRepository.countByMemberIdAndChallengeMemberStatus(memberId, ChallengeMemberStatus.SUCCESS);
 
         // 챌린지 개수 : 멤버 아이디로 챌린지멤버 테이블 카운트
         Long countChallenge = challengeMemberRepository.countByMemberId(memberId);
 
         // 실패한 챌린지 개수
-        Long countFailedChallenge = challengeMemberRepository.countByMemberIdAndChallengeStatus(memberId, ChallengeMemberStatus.FAIL);
+        Long countFailedChallenge = challengeMemberRepository.countByMemberIdAndChallengeMemberStatus(memberId, ChallengeMemberStatus.FAIL);
 
         // 찜 개수 : 회원 아이디로 챌린지라이크 테이블 접근해서 카운트
         Long countlike = challengeLikeRepository.countByMemberId(memberId);

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeMemberStatus.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeMemberStatus.java
@@ -2,5 +2,5 @@ package site.beilsang.beilsang_server_v2.global.enums;
 
 public enum ChallengeMemberStatus {
 
-    SUCCESS, FAIL, ONGOING, NOT_YET
+    SUCCESS, FAIL, ONGOING, NOT_YET, NOT_JOINED
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeMemberStatus.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeMemberStatus.java
@@ -1,6 +1,6 @@
 package site.beilsang.beilsang_server_v2.global.enums;
 
-public enum ChallengeStatus {
+public enum ChallengeMemberStatus {
 
     SUCCESS, FAIL, ONGOING, NOT_YET
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeStatus.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeStatus.java
@@ -1,0 +1,6 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum ChallengeStatus {
+
+    NOT_YET, IN_PROGRESS, END
+}

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImplTest.java
@@ -12,6 +12,8 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRe
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.global.config.QueryDslConfig;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengePeriod;
 
 import java.time.LocalDate;
 
@@ -25,7 +27,7 @@ class ChallengeRepositoryImplTest {
     private ChallengeRepository challengeRepository;
 
     @Test
-    @DisplayName("isFinished=true이면 종료된 챌린지만 조회된다")
+    @DisplayName("ChallengeStatus.END로 종료된 챌린지만 조회된다")
     void findFinishedChallenges() {
         // given
         Challenge finished = Challenge.builder()
@@ -33,18 +35,28 @@ class ChallengeRepositoryImplTest {
                 .category(Category.BIKE)
                 .startDate(LocalDate.now().minusDays(10))
                 .finishDate(LocalDate.now().minusDays(1))
+                .status(ChallengeStatus.END)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
                 .build();
         Challenge ongoing = Challenge.builder()
                 .title("진행중 챌린지")
                 .category(Category.BIKE)
                 .startDate(LocalDate.now().minusDays(1))
                 .finishDate(LocalDate.now().plusDays(5))
+                .status(ChallengeStatus.IN_PROGRESS)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
                 .build();
         challengeRepository.save(finished);
         challengeRepository.save(ongoing);
 
         ChallengeListReqDTO dto = new ChallengeListReqDTO();
-        dto.setIsFinished(true);
+        dto.setChallengeStatus(ChallengeStatus.END);
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
@@ -56,7 +68,7 @@ class ChallengeRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("isFinished=false이면 아직 종료되지 않은 챌린지만 조회된다")
+    @DisplayName("ChallengeStatus.IN_PROGRESS로 진행중인 챌린지만 조회된다")
     void findOngoingChallenges() {
         // given
         Challenge finished = Challenge.builder()
@@ -64,18 +76,28 @@ class ChallengeRepositoryImplTest {
                 .category(Category.BIKE)
                 .startDate(LocalDate.now().minusDays(10))
                 .finishDate(LocalDate.now().minusDays(1))
+                .status(ChallengeStatus.END)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
                 .build();
         Challenge ongoing = Challenge.builder()
                 .title("진행중 챌린지")
                 .category(Category.BIKE)
                 .startDate(LocalDate.now().minusDays(1))
                 .finishDate(LocalDate.now().plusDays(5))
+                .status(ChallengeStatus.IN_PROGRESS)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
                 .build();
         challengeRepository.save(finished);
         challengeRepository.save(ongoing);
 
         ChallengeListReqDTO dto = new ChallengeListReqDTO();
-        dto.setIsFinished(false);
+        dto.setChallengeStatus(ChallengeStatus.IN_PROGRESS);
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
@@ -83,5 +105,99 @@ class ChallengeRepositoryImplTest {
 
         // then
         assertThat(result.getContent()).extracting("title").containsExactly("진행중 챌린지");
+    }
+
+    @Test
+    @DisplayName("ChallengeStatus로 직접 필터링이 가능하다")
+    void findByChallengeStatus() {
+        // given
+        Challenge notYet = Challenge.builder()
+                .title("시작 전 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now().plusDays(3))
+                .finishDate(LocalDate.now().plusDays(10))
+                .status(ChallengeStatus.NOT_YET)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
+                .build();
+        Challenge inProgress = Challenge.builder()
+                .title("진행중 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now().minusDays(1))
+                .finishDate(LocalDate.now().plusDays(5))
+                .status(ChallengeStatus.IN_PROGRESS)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
+                .build();
+        Challenge ended = Challenge.builder()
+                .title("종료된 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now().minusDays(10))
+                .finishDate(LocalDate.now().minusDays(1))
+                .status(ChallengeStatus.END)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("설명")
+                .joinPoint(100)
+                .build();
+        challengeRepository.save(notYet);
+        challengeRepository.save(inProgress);
+        challengeRepository.save(ended);
+
+        ChallengeListReqDTO dto = new ChallengeListReqDTO();
+        dto.setChallengeStatus(ChallengeStatus.IN_PROGRESS);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Challenge> result = challengeRepository.findChallenges(dto, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent()).extracting("title").containsExactly("진행중 챌린지");
+    }
+
+    @Test
+    @DisplayName("키워드로 제목과 상세내용을 검색할 수 있다")
+    void findByKeyword() {
+        // given
+        Challenge challenge1 = Challenge.builder()
+                .title("플로깅 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now())
+                .finishDate(LocalDate.now().plusDays(7))
+                .status(ChallengeStatus.IN_PROGRESS)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("환경보호를 위한 활동")
+                .joinPoint(100)
+                .build();
+        Challenge challenge2 = Challenge.builder()
+                .title("러닝 챌린지")
+                .category(Category.PLOGGING)
+                .startDate(LocalDate.now())
+                .finishDate(LocalDate.now().plusDays(7))
+                .status(ChallengeStatus.IN_PROGRESS)
+                .period(ChallengePeriod.WEEK)
+                .totalGoalDay(5)
+                .details("건강한 플로깅을 해봅시다")
+                .joinPoint(100)
+                .build();
+        challengeRepository.save(challenge1);
+        challengeRepository.save(challenge2);
+
+        ChallengeListReqDTO dto = new ChallengeListReqDTO();
+        dto.setKeyword("플로깅");
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Challenge> result = challengeRepository.findChallenges(dto, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).extracting("title").containsExactlyInAnyOrder("플로깅 챌린지", "러닝 챌린지");
     }
 }

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -95,6 +95,7 @@ class ChallengeServiceImplTest {
                 .period(ChallengePeriod.WEEK)
                 .totalGoalDay(5)
                 .details("테스트 챌린지 설명")
+                .status(ChallengeStatus.NOT_YET)
                 .attendeeCount(1)
                 .countLikes(0)
                 .collectedPoint(100)
@@ -113,6 +114,7 @@ class ChallengeServiceImplTest {
                 .period(ChallengePeriod.WEEK)
                 .totalGoalDay(5)
                 .details("테스트 챌린지 설명")
+                .status(ChallengeStatus.IN_PROGRESS)
                 .attendeeCount(1)
                 .countLikes(0)
                 .collectedPoint(100)
@@ -126,11 +128,12 @@ class ChallengeServiceImplTest {
                 .title("테스트 챌린지")
                 .category(Category.PLOGGING)
                 .startDate(LocalDate.now().minusDays(5))
-                .finishDate(LocalDate.now().plusDays(1))
+                .finishDate(LocalDate.now().minusDays(1))
                 .joinPoint(100)
                 .period(ChallengePeriod.WEEK)
                 .totalGoalDay(5)
                 .details("테스트 챌린지 설명")
+                .status(ChallengeStatus.END)
                 .attendeeCount(1)
                 .countLikes(0)
                 .collectedPoint(100)
@@ -225,7 +228,7 @@ class ChallengeServiceImplTest {
         CreateChallengeReqDTO todayStartReqDTO = createTestChallengeReqDTOWithStartDate(LocalDate.now());
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
-        when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_NOT_YET);
+        when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_ONGOING);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
@@ -282,7 +285,7 @@ class ChallengeServiceImplTest {
         Long challengeId = 1L;
 
         when(challengeRepository.getChallengeById(challengeId)).thenReturn(challenge_ONGOING);
-        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(null);
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(Optional.empty());
 
         // when
         var result = challengeService.getChallengeDetail(challengeId, memberId);
@@ -290,7 +293,7 @@ class ChallengeServiceImplTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getIsJoinable()).isTrue();
-        assertThat(result.getStatus()).isEqualTo(ChallengeMemberStatus.ONGOING);
+        assertThat(result.getStatus()).isEqualTo(ChallengeMemberStatus.NOT_JOINED);
         assertThat(result.getProgress()).isNull();
     }
 

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -213,7 +213,7 @@ class ChallengeServiceImplTest {
         ArgumentCaptor<ChallengeMember> challengeMemberCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
         verify(challengeMemberRepository).save(challengeMemberCaptor.capture());
         ChallengeMember savedChallengeMember = challengeMemberCaptor.getValue();
-        assertThat(savedChallengeMember.getChallengeStatus()).isEqualTo(ChallengeStatus.NOT_YET);
+        assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.NOT_YET);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class), any(MultipartFile.class));
     }
 
@@ -240,7 +240,7 @@ class ChallengeServiceImplTest {
         ArgumentCaptor<ChallengeMember> challengeMemberCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
         verify(challengeMemberRepository).save(challengeMemberCaptor.capture());
         ChallengeMember savedChallengeMember = challengeMemberCaptor.getValue();
-        assertThat(savedChallengeMember.getChallengeStatus()).isEqualTo(ChallengeStatus.ONGOING);
+        assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.ONGOING);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class), any(MultipartFile.class));
     }
 
@@ -290,7 +290,7 @@ class ChallengeServiceImplTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getIsJoinable()).isTrue();
-        assertThat(result.getStatus()).isEqualTo(ChallengeStatus.ONGOING);
+        assertThat(result.getStatus()).isEqualTo(ChallengeMemberStatus.ONGOING);
         assertThat(result.getProgress()).isNull();
     }
 


### PR DESCRIPTION
## 📌 이슈 번호

  - closed #28

## 🍬 기능 설명

- ChallengeStatus 분리: 기존 ChallengeStatus를 ChallengeMemberStatus로 변경하고, 새로운 ChallengeStatus  enum을 추가하여 챌린지 전체 상태와 멤버별 참여 상태를 명확히 분리
- Challenge 엔티티 개선: status 필드 추가 및 자동 상태 업데이트를 위한 스케줄러 서비스 구현 (ChallengeStatusScheduler)
- ChallengeServiceImpl 최적화: Optional 기반 하이브리드 접근 방식 적용으로 가독성 향상, 포인트 계산 헬퍼 메서드 분리
- ChallengeRepositoryImpl 개선:
  - 복잡한 필터링 로직을 역할별 헬퍼 함수로 분리 (가독성 향상)
  - 키워드 검색 기능 추가 (제목 + 상세내용 검색)
  - ChallengeStatus 직접 필터링 지원
  - 참여 여부 필터링 버그 수정 (ne() → not() 로직)
  - 날짜 계산 로직을 Challenge.status 필드 기반으로 변경하여 정확성 향상 
- ChallengeMemberStatus에 NOT_JOINED 상태 추가: 미참여 사용자 상태 명확화

##  🤔 코드 리뷰에서 집중적으로 볼 내용

1. ChallengeRepositoryImpl 헬퍼 함수 분리
```java
// 기존: 복잡한 단일 메서드
public Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable) {
// 복잡한 로직 ...
}

// 개선: 역할별 헬퍼 함수 분리
private void addCategoryFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO)
private void addKeywordFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO)  
private void addChallengeStatusFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO)
private void addMembershipFilter(BooleanBuilder builder, QChallenge challenge, ChallengeListReqDTO requestDTO)
```

2. 참여 여부 필터링 직관적으로 수정

```java
// 수정 전 
builder.and(challenge.challengeMembers.any().member.id.ne(requestDTO.getMemberId()));

// 수정 후
builder.and(challenge.challengeMembers.any().member.id.eq(requestDTO.getMemberId()).not());
```

3. ChallengeServiceImpl 하이브리드 접근 방식

```java
// 간단한 로직: 인라인 처리
ChallengeMemberStatus status = challengeMemberOpt
    .map(ChallengeMember::getChallengeMemberStatus)
    .orElse(ChallengeMemberStatus.NOT_JOINED);

// 복잡한 로직: 별도 메서드 분리
private Integer calculatePointSum(List<PointLog> pointLogs, PointStatus targetStatus) {
    return pointLogs.stream()
        .filter(pointLog -> pointLog.getStatus() == targetStatus)
        .mapToInt(PointLog::getValue)
        .sum();
}
```

  4. Challenge 생성 시 상태 로직

```java
// Challenge의 현재 상태를 기반으로 ChallengeMemberStatus 결정
ChallengeMemberStatus challengeMemberStatus = challenge.getStatus() == ChallengeStatus.NOT_YET ? ChallengeMemberStatus.NOT_YET : ChallengeMemberStatus.ONGOING;
```

## ⭐ 기타 사항

- 테스트 커버리지: 모든 변경사항에 대한 단위 테스트 업데이트 완료 (17개 테스트 통과)
- 확장성: 헬퍼 함수 구조로 새로운 필터링 조건 추가 용이
- 자동화: 매일 자정 챌린지 상태 자동 업데이트 스케줄러 적용 (@Scheduled(cron = "0 0 0 * * *"))