### PR TITLE
[Feat] 챌린지 참여 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ out/
 ### Claude Code ###
 CLAUDE.md
 claude/*
+
+### Logs ###
+logs

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ out/
 
 ### Claude Code ###
 CLAUDE.md
+claude/*

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -16,6 +16,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallenge
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.JoinChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.service.ChallengeService;
 import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
 import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
@@ -53,5 +54,13 @@ public class ChallengeController {
             Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.getChallengeDetail(challengeId, memberId));
+    }
+
+    @PostMapping("/{challengeId}/join")
+    public BaseResponse<JoinChallengeResDTO> joinChallenge(
+            @PathVariable Long challengeId,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(challengeService.joinChallenge(challengeId, memberId));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.JoinChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -128,5 +129,9 @@ public class ChallengeAssembler {
                 .usedPoint(usedPoint)
                 .earnedPoint(earnedPoint)
                 .build();
+    }
+
+    public static JoinChallengeResDTO toJoinChallengeResDTO(Challenge challenge) {
+        return JoinChallengeResDTO.builder().build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -131,7 +131,12 @@ public class ChallengeAssembler {
                 .build();
     }
 
-    public static JoinChallengeResDTO toJoinChallengeResDTO(Challenge challenge) {
-        return JoinChallengeResDTO.builder().build();
+    public static JoinChallengeResDTO toJoinChallengeResDTO(Challenge challenge, Long memberId, Integer remainingPoint) {
+        return JoinChallengeResDTO.builder()
+                .challengeId(challenge.getId())
+                .memberId(memberId)
+                .joinDate(java.time.LocalDateTime.now())
+                .remainingPoint(remainingPoint)
+                .build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/JoinChallengeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/JoinChallengeResDTO.java
@@ -1,0 +1,38 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 챌린지 참여 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinChallengeResDTO {
+    
+    /**
+     * 참여한 챌린지 ID
+     */
+    private Long challengeId;
+    
+    /**
+     * 참여한 멤버 ID
+     */
+    private Long memberId;
+    
+    /**
+     * 참여 일시
+     */
+    private LocalDateTime joinDate;
+    
+    /**
+     * 참여 후 남은 포인트
+     */
+    private Integer remainingPoint;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -86,4 +86,11 @@ public class Challenge extends BaseEntity {
             return ChallengeStatus.IN_PROGRESS;
         }
     }
+
+    /**
+     * 챌린지 참여자 수 증가
+     */
+    public void incrementAttendeeCount() {
+        this.attendeeCount++;
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -8,6 +8,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRe
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.JoinChallengeResDTO;
 
 public interface ChallengeService {
 
@@ -17,4 +18,6 @@ public interface ChallengeService {
     PageResponseDTO<ChallengeListResDTO> getChallengeList(ChallengeListReqDTO requestDTO);
 
     ChallengeDetailResDTO getChallengeDetail(Long challengeId, Long memberId);
+
+    JoinChallengeResDTO joinChallenge(Long challengeId, Long memberId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -300,8 +300,11 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 챌린지 참여자 수 증가
         challenge.incrementAttendeeCount();
 
+        // 참여 후 남은 포인트 계산
+        Integer remainingPoint = pointService.calculateValidPoints(memberId);
+
         // 응답 DTO 생성 및 반환
-        return ChallengeAssembler.toJoinChallengeResDTO(challenge);
+        return ChallengeAssembler.toJoinChallengeResDTO(challenge, memberId, remainingPoint);
     }
 
     private Integer calculatePointSum(List<PointLog> pointLogs, PointStatus targetStatus) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -12,6 +12,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.JoinChallengeResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeNote;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeInfoImage;
@@ -239,6 +240,11 @@ public class ChallengeServiceImpl implements ChallengeService {
         return ChallengeAssembler.toChallengeDetailResDTO(
                 challenge, isJoinable, status, progress, usedPoint, earnedPoint
         );
+    }
+
+    @Override
+    public JoinChallengeResDTO joinChallenge(Long challengeId, Long memberId) {
+        return null;
     }
 
     private Integer calculatePointSum(List<PointLog> pointLogs, PointStatus targetStatus) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -50,6 +50,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private static final int MAX_INFO_IMAGE = 5;
     private static final int MAX_CERT_IMAGE = 4;
     private static final int POINT_EXPIRATION_YEARS = 1;
+    private static final int INIT_SUCCESS_DAYS = 0;
 
     private final MemberRepository memberRepository;
     private final ChallengeRepository challengeRepository;
@@ -120,7 +121,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         // ChallengeMember 생성
         challengeMemberRepository.save(ChallengeMember.builder()
                 .isHost(true)
-                .successDays(0)
+                .successDays(INIT_SUCCESS_DAYS)
                 .challengeMemberStatus(challengeMemberStatus)
                 .isFeedUpload(false)
                 .member(member)
@@ -244,7 +245,63 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public JoinChallengeResDTO joinChallenge(Long challengeId, Long memberId) {
-        return null;
+        // 챌린지 조회
+        Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(
+                () -> new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE));
+
+        // 멤버 조회
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        // 이미 참여한 챌린지인지 확인
+        if (challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId).isPresent()) {
+            throw new BaseException(BaseResponseCode.ALREADY_JOINED_CHALLENGE);
+        }
+
+        // 종료된 챌린지인지 확인
+        if (challenge.getStatus() == ChallengeStatus.END) {
+            throw new BaseException(BaseResponseCode.CHALLENGE_ENDED);
+        }
+
+        // 참여 포인트 확인 및 차감
+        int joinPoint = challenge.getJoinPoint();
+        int validPoints = pointService.calculateValidPoints(memberId);
+        if (validPoints < joinPoint) {
+            throw new BaseException(BaseResponseCode.NOT_ENOUGH_POINT);
+        }
+
+        // 포인트 로그 생성
+        pointLogRepository.save(PointLog.builder()
+                .pointName(PointName.JOIN_CHALLENGE)
+                .status(PointStatus.USE)
+                .value(joinPoint)
+                .expirationDate(LocalDateTime.now().plusYears(POINT_EXPIRATION_YEARS))
+                .member(member)
+                .challenge(challenge)
+                .build());
+        
+        // 멤버 포인트 차감
+        member.subPoint(joinPoint);
+
+        // 챌린지 멤버 상태 결정
+        ChallengeMemberStatus challengeMemberStatus = challenge.getStatus() == ChallengeStatus.NOT_YET ? 
+                ChallengeMemberStatus.NOT_YET : ChallengeMemberStatus.ONGOING;
+
+        // 챌린지 멤버 생성
+        challengeMemberRepository.save(ChallengeMember.builder()
+                .isHost(false)
+                .successDays(INIT_SUCCESS_DAYS)
+                .challengeMemberStatus(challengeMemberStatus)
+                .isFeedUpload(false)
+                .member(member)
+                .challenge(challenge)
+                .build());
+
+        // 챌린지 참여자 수 증가
+        challenge.incrementAttendeeCount();
+
+        // 응답 DTO 생성 및 반환
+        return ChallengeAssembler.toJoinChallengeResDTO(challenge);
     }
 
     private Integer calculatePointSum(List<PointLog> pointLogs, PointStatus targetStatus) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -29,7 +29,9 @@ public enum BaseResponseCode {
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "C0001", "유효하지 않은 이미지 파일입니다"),
     INVALID_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "C0002", "목표 실천일수가 챌린지 기간을 초과할 수 없습니다"),
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "C0003", "시작 날짜는 오늘 이후여야 합니다"),
-    NOT_FOUND_CHALLENGE(HttpStatus.BAD_REQUEST, "C0004", "존재하지 않는 챌린지입니다");
+    NOT_FOUND_CHALLENGE(HttpStatus.BAD_REQUEST, "C0004", "존재하지 않는 챌린지입니다"),
+    ALREADY_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0005", "이미 참여한 챌린지입니다"),
+    CHALLENGE_ENDED(HttpStatus.BAD_REQUEST, "C0006", "종료된 챌린지입니다");
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -59,6 +59,10 @@ class ChallengeServiceImplTest {
     @Mock
     private S3Service s3Service;
 
+    @Mock
+    private site.beilsang.beilsang_server_v2.domain.point.service.PointService pointService;
+
+
     @InjectMocks
     private ChallengeServiceImpl challengeService;
 
@@ -180,6 +184,7 @@ class ChallengeServiceImplTest {
                 .build();
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberWithLowPoint));
+        when(pointService.calculateValidPoints(memberId)).thenReturn(50); // 부족한 포인트
 
         // when & then
         assertThatThrownBy(() -> challengeService.createChallenge(
@@ -201,6 +206,7 @@ class ChallengeServiceImplTest {
         CreateChallengeReqDTO futureStartReqDTO = createTestChallengeReqDTOWithStartDate(LocalDate.now().plusDays(10));
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(pointService.calculateValidPoints(memberId)).thenReturn(200); // 충분한 포인트
         when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_NOT_YET);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
@@ -295,6 +301,187 @@ class ChallengeServiceImplTest {
         assertThat(result.getIsJoinable()).isTrue();
         assertThat(result.getStatus()).isEqualTo(ChallengeMemberStatus.NOT_JOINED);
         assertThat(result.getProgress()).isNull();
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 성공 - NOT_YET 상태 챌린지")
+    void joinChallenge_Success_NotYetStatus() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+        Integer remainingPoint = 900;
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge_NOT_YET));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(Optional.empty());
+        when(pointService.calculateValidPoints(memberId)).thenReturn(200, 100); // 충분한 포인트, 참여 후 포인트
+        when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
+        when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
+
+        // when
+        var result = challengeService.joinChallenge(challengeId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+
+        // then
+        verify(challengeRepository).findById(challengeId);
+        verify(memberRepository).findById(memberId);
+        verify(challengeMemberRepository).findByChallengeIdAndMemberId(challengeId, memberId);
+        verify(pointService, times(2)).calculateValidPoints(memberId);
+        verify(pointLogRepository).save(any(PointLog.class));
+        verify(challengeMemberRepository).save(any(ChallengeMember.class));
+        
+        // ChallengeMember 저장 시 올바른 상태인지 확인
+        ArgumentCaptor<ChallengeMember> challengeMemberCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
+        verify(challengeMemberRepository).save(challengeMemberCaptor.capture());
+        ChallengeMember savedChallengeMember = challengeMemberCaptor.getValue();
+        
+        assertThat(savedChallengeMember.getIsHost()).isFalse();
+        assertThat(savedChallengeMember.getSuccessDays()).isEqualTo(0);
+        assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.NOT_YET);
+        assertThat(savedChallengeMember.getIsFeedUpload()).isFalse();
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 성공 - ONGOING 상태 챌린지")
+    void joinChallenge_Success_OngoingStatus() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+        Integer remainingPoint = 900;
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge_ONGOING));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(Optional.empty());
+        when(pointService.calculateValidPoints(memberId)).thenReturn(200, 100); // 충분한 포인트, 참여 후 포인트
+        when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
+        when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
+
+        // when
+        var result = challengeService.joinChallenge(challengeId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+
+        // then
+        // ChallengeMember 저장 시 올바른 상태인지 확인
+        ArgumentCaptor<ChallengeMember> challengeMemberCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
+        verify(challengeMemberRepository).save(challengeMemberCaptor.capture());
+        ChallengeMember savedChallengeMember = challengeMemberCaptor.getValue();
+        
+        assertThat(savedChallengeMember.getIsHost()).isFalse();
+        assertThat(savedChallengeMember.getSuccessDays()).isEqualTo(0);
+        assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.ONGOING);
+        assertThat(savedChallengeMember.getIsFeedUpload()).isFalse();
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 실패 - 존재하지 않는 챌린지")
+    void joinChallenge_Fail_ChallengeNotFound() {
+        // given
+        Long challengeId = 999L;
+        Long memberId = 2L;
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.joinChallenge(challengeId, memberId))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("baseResponseCode", BaseResponseCode.NOT_FOUND_CHALLENGE);
+
+        verify(challengeRepository).findById(challengeId);
+        verifyNoInteractions(memberRepository, challengeMemberRepository, pointService, pointLogRepository);
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 실패 - 존재하지 않는 멤버")
+    void joinChallenge_Fail_MemberNotFound() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 999L;
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge_NOT_YET));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.joinChallenge(challengeId, memberId))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("baseResponseCode", BaseResponseCode.NOT_FOUND_MEMBER);
+
+        verify(challengeRepository).findById(challengeId);
+        verify(memberRepository).findById(memberId);
+        verifyNoInteractions(challengeMemberRepository, pointService, pointLogRepository);
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 실패 - 이미 참여한 챌린지")
+    void joinChallenge_Fail_AlreadyJoined() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+        ChallengeMember existingMember = mock(ChallengeMember.class);
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge_NOT_YET));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId))
+                .thenReturn(Optional.of(existingMember));
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.joinChallenge(challengeId, memberId))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("baseResponseCode", BaseResponseCode.ALREADY_JOINED_CHALLENGE);
+
+        verify(challengeRepository).findById(challengeId);
+        verify(memberRepository).findById(memberId);
+        verify(challengeMemberRepository).findByChallengeIdAndMemberId(challengeId, memberId);
+        verifyNoInteractions(pointService, pointLogRepository);
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 실패 - 종료된 챌린지")
+    void joinChallenge_Fail_ChallengeEnded() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge_ENDED));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.joinChallenge(challengeId, memberId))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("baseResponseCode", BaseResponseCode.CHALLENGE_ENDED);
+
+        verify(challengeRepository).findById(challengeId);
+        verify(memberRepository).findById(memberId);
+        verify(challengeMemberRepository).findByChallengeIdAndMemberId(challengeId, memberId);
+        verifyNoInteractions(pointService, pointLogRepository);
+    }
+
+    @Test
+    @DisplayName("챌린지 참여 실패 - 포인트 부족")
+    void joinChallenge_Fail_NotEnoughPoint() {
+        // given
+        Long challengeId = 1L;
+        Long memberId = 2L;
+        
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge_NOT_YET));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)).thenReturn(Optional.empty());
+        when(pointService.calculateValidPoints(memberId)).thenReturn(50); // 부족한 포인트 (joinPoint는 100)
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.joinChallenge(challengeId, memberId))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("baseResponseCode", BaseResponseCode.NOT_ENOUGH_POINT);
+
+        verify(challengeRepository).findById(challengeId);
+        verify(memberRepository).findById(memberId);
+        verify(challengeMemberRepository).findByChallengeIdAndMemberId(challengeId, memberId);
+        verify(pointService).calculateValidPoints(memberId);
+        verifyNoMoreInteractions(pointLogRepository);
     }
 
     // 테스트 데이터 생성 헬퍼 메서드들

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -234,6 +234,7 @@ class ChallengeServiceImplTest {
         CreateChallengeReqDTO todayStartReqDTO = createTestChallengeReqDTOWithStartDate(LocalDate.now());
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(pointService.calculateValidPoints(memberId)).thenReturn(200); // 충분한 포인트
         when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_ONGOING);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));
@@ -267,6 +268,7 @@ class ChallengeServiceImplTest {
                 .build();
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberWithPoint));
+        when(pointService.calculateValidPoints(memberId)).thenReturn(200); // 충분한 포인트
         when(challengeRepository.save(any(Challenge.class))).thenReturn(challenge_NOT_YET);
         when(challengeNoteRepository.saveAll(any(List.class))).thenReturn(Arrays.asList());
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(mock(ChallengeMember.class));


### PR DESCRIPTION
## 📌 이슈 번호 #27
- 챌린지 참여 기능 구현 

## 🍬 기능 설명
- 사용자가 기존 챌린지에 참여할 수 있는 REST API 엔드포인트 구현
- JWT 인증을 통한 멤버 식별 및 챌린지 참여 처리
- 포인트 시스템 연동으로 참여비 차감 및 검증
- 참여 시 챌린지 상태에 따른 멤버 상태 자동 설정
- 중복 참여, 종료된 챌린지 참여 등 예외 상황 처리

## 🤔 코드 리뷰에서 집중적으로 볼 내용

### 1. ChallengeMember 상태 설정 로직
```java
// 챌린지 상태에 따른 멤버 상태 자동 결정
ChallengeMemberStatus challengeMemberStatus = challenge.getStatus() == ChallengeStatus.NOT_YET ? 
        ChallengeMemberStatus.NOT_YET : ChallengeMemberStatus.ONGOING;
```
- 챌린지가 아직 시작하지 않았으면 NOT_YET, 진행 중이면 ONGOING으로 설정
- 이 로직이 올바른지 검토 필요

### 2. 포인트 차감 및 검증 순서
```java
// 1. 먼저 유효 포인트 확인
int validPoints = pointService.calculateValidPoints(memberId);
if (validPoints < joinPoint) {
    throw new BaseException(BaseResponseCode.NOT_ENOUGH_POINT);
}

// 2. 포인트 로그 생성 및 멤버 포인트 차감
pointLogRepository.save(PointLog.builder()...);
member.subPoint(joinPoint);
```
- 포인트 검증 후 차감하는 순서가 올바른지 확인
- 트랜잭션 롤백 시 데이터 일관성 보장 여부

### 3. 예외 처리 우선순위
참여 검증 순서:
1. 챌린지 존재 여부
2. 멤버 존재 여부  
3. 중복 참여 여부
4. 챌린지 종료 여부
5. 포인트 부족 여부

이 순서가 비즈니스 로직상 적절한지 검토

### 4. ChallengeAssembler 메서드 시그니처
```java
public static JoinChallengeResDTO toJoinChallengeResDTO(Challenge challenge, Long memberId, Integer remainingPoint)
```
- Challenge 엔티티만으로는 memberId와 remainingPoint를 알 수 없어서 파라미터 추가
- 더 좋은 설계 방법이 있는지 검토

## ⭐ 기타 사항

### 참고한 레퍼런스
- Spring Boot Testing Guide: Mock 설정 및 ArgumentCaptor 사용법
- JUnit 5 + Mockito: 테스트 격리 및 검증 방법

### 테스트 커버리지
- 성공 케이스: 2개 (NOT_YET, ONGOING 상태별)
- 예외 케이스: 5개 (챌린지/멤버 없음, 중복참여, 종료됨, 포인트부족)
- **총 7개 테스트 케이스 모두 통과**