### PR TITLE
Refac: 스웨거 테스트 수정 (Swagger 호환성, 엔티티 초기화)

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -43,12 +44,12 @@ public class ChallengeController {
         @ApiResponse(responseCode = "400", description = "잘못된 요청"),
         @ApiResponse(responseCode = "401", description = "인증 실패")
     })
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<ChallengeResDTO> createChallenge(
         Authentication authentication,
         @Parameter(description = "챌린지 생성 요청 데이터") @RequestPart("data") CreateChallengeReqDTO createChallengeReqDTO,
-        @Parameter(description = "챌린지 정보 이미지들") @RequestPart("infoImages") List<MultipartFile> infoImages,
-        @Parameter(description = "인증 방법 이미지들") @RequestPart("certImages") List<MultipartFile> certImages) {
+        @Parameter(description = "챌린지 정보 이미지들") @RequestPart(value = "infoImages") List<MultipartFile> infoImages,
+        @Parameter(description = "인증 방법 이미지들") @RequestPart(value = "certImages") List<MultipartFile> certImages) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(
             challengeService.createChallenge(memberId, createChallengeReqDTO, infoImages,

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -52,21 +52,27 @@ public class Challenge extends BaseEntity {
 
     private String details;
 
+    @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChallengeInfoImage> infoImages = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChallengeCertImage> certImages = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeNote> challengeNotes = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeLike> challengeLikes = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Feed> feeds = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeMember> challengeMembers = new ArrayList<>();
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -84,9 +84,6 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 멤버 포인트 부족 시 예외 처리
         int joinPoint = createChallengeReqDTO.getJoinPoint();
         int validPoints = pointService.calculateValidPoints(memberId);
-        System.out.println("=============================");
-        System.out.println(validPoints);
-        System.out.println("=============================");
         if (validPoints < joinPoint) {
             throw new BaseException(BaseResponseCode.NOT_ENOUGH_POINT);
         }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -84,6 +84,9 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 멤버 포인트 부족 시 예외 처리
         int joinPoint = createChallengeReqDTO.getJoinPoint();
         int validPoints = pointService.calculateValidPoints(memberId);
+        System.out.println("=============================");
+        System.out.println(validPoints);
+        System.out.println("=============================");
         if (validPoints < joinPoint) {
             throw new BaseException(BaseResponseCode.NOT_ENOUGH_POINT);
         }
@@ -94,7 +97,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         pointLogRepository.save(PointLog.builder()
             .pointName(PointName.JOIN_CHALLENGE)
             .status(PointStatus.USE)
-            .value(joinPoint)
+            .points(joinPoint)
             .expirationDate(LocalDateTime.now().plusYears(POINT_EXPIRATION_YEARS))
             .member(member)
             .challenge(challenge)
@@ -281,7 +284,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
             .pointName(PointName.JOIN_CHALLENGE)
             .status(PointStatus.USE)
-            .value(joinPoint)
+            .points(joinPoint)
             .expirationDate(LocalDateTime.now().plusYears(POINT_EXPIRATION_YEARS))
             .member(member)
             .challenge(challenge)
@@ -318,7 +321,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private Integer calculatePointSum(List<PointLog> pointLogs, PointStatus targetStatus) {
         return pointLogs.stream()
             .filter(pointLog -> pointLog.getStatus() == targetStatus)
-            .mapToInt(PointLog::getValue)
+            .mapToInt(PointLog::getPoints)
             .sum();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -77,7 +78,7 @@ public class FeedController {
         @ApiResponse(responseCode = "401", description = "인증 실패"),
         @ApiResponse(responseCode = "403", description = "챌린지 참여자가 아님")
     })
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<FeedCreateResDTO> createFeed(
         Authentication authentication,
         @Parameter(description = "피드 작성 요청 데이터") @RequestPart("data") FeedCreateReqDTO createReqDTO,

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/entity/Feed.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/entity/Feed.java
@@ -48,6 +48,7 @@ public class Feed extends BaseEntity {
     @JoinColumn(name = "challenge_member_id")
     private ChallengeMember challengeMember;
 
+    @Builder.Default
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<FeedLike> feedLikes = new ArrayList<>();
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
@@ -52,6 +52,7 @@ public class ChallengeMember extends BaseEntity {
     @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
+    @Builder.Default
     @OneToMany(mappedBy = "challengeMember", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Feed> feed = new ArrayList<>();
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
@@ -78,16 +78,19 @@ public class Member {
 
     private String deviceToken;
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<PointLog> pointLogs = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeMember> challengeMembers = new ArrayList<>();
 
-
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<FeedLike> feedLikes = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeLike> challengeLikes = new ArrayList<>();
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/dto/PointAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/dto/PointAssembler.java
@@ -21,7 +21,7 @@ public class PointAssembler {
     public static PointLogResDTO toEntity(PointLog pointLog) {
         return PointLogResDTO.builder()
             .id(pointLog.getId())
-            .value(pointLog.getValue())
+            .value(pointLog.getPoints())
 //                .name(pointLog.getName())
 //                .period(pointLog.getPeriod())
             .date(pointLog.getCreatedAt().toLocalDate())

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/entity/PointLog.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/entity/PointLog.java
@@ -41,7 +41,7 @@ public class PointLog extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PointStatus status;
 
-    private int value;
+    private int points;
 
     private LocalDateTime expirationDate;
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/service/PointService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/service/PointService.java
@@ -41,7 +41,7 @@ public class PointService {
 
         return pointLogs.stream()
             .filter(p -> p.getStatus() != PointStatus.EXPIRE)
-            .mapToInt(PointLog::getValue)
+            .mapToInt(PointLog::getPoints)
             .sum();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/SwaggerConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/SwaggerConfig.java
@@ -7,8 +7,11 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.ArrayList;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
 /**
  * Swagger/OpenAPI 3 설정 클래스 API 문서화를 위한 기본 정보 및 보안 스키마를 정의합니다.
@@ -59,5 +62,17 @@ public class SwaggerConfig {
             .scheme("bearer")
             .bearerFormat("JWT")
             .description("JWT 토큰을 입력하세요 (Bearer 접두사 제외)");
+    }
+
+    /**
+     * This method is needed to allow sending multipart requests. For example, when an item is
+     * created together with an image. If this is not set the request will return an exception with:
+     * Resolved [org.springframework.web.HttpMediaTypeNotSupportedException: Content-Type
+     * 'application/octet-stream' is not supported]
+     */
+    public SwaggerConfig(MappingJackson2HttpMessageConverter converter) {
+        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        converter.setSupportedMediaTypes(supportedMediaTypes);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/SwaggerConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/SwaggerConfig.java
@@ -64,15 +64,9 @@ public class SwaggerConfig {
             .description("JWT 토큰을 입력하세요 (Bearer 접두사 제외)");
     }
 
-    /**
-     * This method is needed to allow sending multipart requests. For example, when an item is
-     * created together with an image. If this is not set the request will return an exception with:
-     * Resolved [org.springframework.web.HttpMediaTypeNotSupportedException: Content-Type
-     * 'application/octet-stream' is not supported]
-     */
     public SwaggerConfig(MappingJackson2HttpMessageConverter converter) {
         var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
-        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        supportedMediaTypes.add(MediaType.APPLICATION_OCTET_STREAM);
         converter.setSupportedMediaTypes(supportedMediaTypes);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,10 +32,10 @@ spring:
       s3:
         bucket: beilsang-bucket-dev
         path:
-          challenge-main: challenge/main
-          challenge-cert: challenge/cert
-          member-profile: member/profile
-          feed: feed
+          challenge-main: challenge/main/
+          challenge-cert: challenge/cert/
+          member-profile: member/profile/
+          feed: feed/
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- #46 

## 🍬 기능 설명

### 1. Swagger multipart 요청 호환성 개선
- **문제**: Swagger UI에서 multipart 요청 시 `Content-Type 'application/octet-stream' is not supported` 오류 발생
- **원인**: Swagger가 JSON 데이터를 `application/octet-stream`으로 전송하나, Spring의 `MappingJackson2HttpMessageConverter`가 해당 MediaType 미지원
- **해결**: `SwaggerConfig`에서 `MappingJackson2HttpMessageConverter`에 `application/octet-stream` MediaType 지원 추가

```mermaid
sequenceDiagram
    participant SW as Swagger UI
    participant SC as Spring Controller
    participant MC as MessageConverter
    participant SV as Service Layer

    Note over SW,SV: 문제 상황: application/octet-stream 지원 안됨

    SW->>SC: POST /challenge (multipart/form-data)
    Note right of SW: data: application/octet-stream<br/>files: multipart files

    SC->>MC: @RequestPart("data") 처리 요청
    MC-->>SC: ❌ Unsupported MediaType Error
    Note right of MC: application/octet-stream<br/>미지원으로 변환 실패

    Note over SW,SV: 해결 방안: MessageConverter 확장

    rect rgb(200, 255, 200)
        Note over MC: SwaggerConfig에서<br/>application/octet-stream 추가
        MC->>MC: supportedMediaTypes.add(<br/>"application/octet-stream")
    end

    SW->>SC: POST /challenge (multipart/form-data)
    Note right of SW: data: application/octet-stream<br/>files: multipart files

    SC->>MC: @RequestPart("data") 처리 요청
    MC->>MC: JSON String → CreateChallengeReqDTO 변환
    MC-->>SC: ✅ 변환 성공

    SC->>SV: createChallenge() 호출
    SV-->>SC: ChallengeResDTO 반환
    SC-->>SW: ✅ 200 OK Response
```

### 2. Lombok @Builder 사용 시 컬렉션 필드 null 문제 해결
- **문제**: 챌린지 생성 API 호출 시 `NullPointerException` 발생 (`challenge.getInfoImages().add(infoImage)` 시점)
- **원인**: Lombok의 `@Builder` 어노테이션이 필드의 기본 초기화 값(`= new ArrayList<>()`)을 무시
- **해결**: `@OneToMany` 관계의 모든 컬렉션 필드에 `@Builder.Default` 어노테이션 추가

## 🤔 코드 리뷰에서 집중적으로 볼 내용

### 1. SwaggerConfig 설정 확인
```java
@Configuration
public class SwaggerConfig {
    public SwaggerConfig(MappingJackson2HttpMessageConverter converter) {
        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
        converter.setSupportedMediaTypes(supportedMediaTypes);
    }
}
```
- 생성자 주입을 통한 `MappingJackson2HttpMessageConverter` 확장이 적절한지
- 애플리케이션 시작 시 정상적으로 적용되는지

### 2. @Builder.Default 적용 범위
다음 엔티티들의 컬렉션 필드에 `@Builder.Default` 추가되었는지 확인:

**Challenge 엔티티**
```java
@Builder.Default
@OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
private List<ChallengeInfoImage> infoImages = new ArrayList<>();

@Builder.Default
@OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
private List<ChallengeCertImage> certImages = new ArrayList<>();
```
- `infoImages`, `certImages` 뿐만 아니라 `challengeNotes`, `challengeLikes`, `feeds`, `challengeMembers`에도 적용
  
**Member 엔티티**
- `pointLogs`, `challengeMembers`, `feedLikes`, `challengeLikes` 필드 확인

**Feed 엔티티**
- `feedLikes` 필드 확인

**ChallengeMember 엔티티**
- `feed` 필드 확인

### 3. 놓친 엔티티가 없는지
- 프로젝트 내 `@Builder` + `@OneToMany` 조합을 사용하는 다른 엔티티도 동일하게 적용되었는지

## ⭐ 기타 사항

### 참고 레퍼런스
Swagger multipart 처리 관련: https://margin1103.tistory.com/41
@RequestPart를 활용한 JSON + MultipartFile 동시 전송: [https://dongker.tistory.com/entry/Spring-RequestPart를-활용하여-JSON-MultipartFile-동시-전송하기-Feat-게시판에서-게시물-생성과-첨부-파일-업로드-한번에-처리하기#5.%20@RequestBody%20vs%20@RequestPart%20비교-1-15](https://dongker.tistory.com/entry/Spring-RequestPart%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%98%EC%97%AC-JSON-MultipartFile-%EB%8F%99%EC%8B%9C-%EC%A0%84%EC%86%A1%ED%95%98%EA%B8%B0-Feat-%EA%B2%8C%EC%8B%9C%ED%8C%90%EC%97%90%EC%84%9C-%EA%B2%8C%EC%8B%9C%EB%AC%BC-%EC%83%9D%EC%84%B1%EA%B3%BC-%EC%B2%A8%EB%B6%80-%ED%8C%8C%EC%9D%BC-%EC%97%85%EB%A1%9C%EB%93%9C-%ED%95%9C%EB%B2%88%EC%97%90-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0#5.%20@RequestBody%20vs%20@RequestPart%20%EB%B9%84%EA%B5%90-1-15)
multipart/form-data 처리: https://kingmusung.tistory.com/78
Lombok @Builder 공식 문서: https://projectlombok.org/features/Builder
JPA OneToMany 관계 매핑: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/

### Lombok @Builder 사용 시 주의사항
- `@Builder`는 필드의 기본 초기화(`= new ArrayList<>()`)를 무시함
- `@OneToMany` 컬렉션 필드는 반드시 `@Builder.Default` 어노테이션 추가 필요
- 빌더로 객체 생성 시 명시하지 않은 컬렉션은 `null`이 되므로 주의

### 대안 해결 방법 (참고용)
만약 `@Builder.Default`를 사용할 수 없는 경우:
1. **생성자에서 명시적 초기화**
2. **Getter에서 null 체크 후 초기화**
3. **빌더 사용 시 명시적 설정** (예: `.infoImages(new ArrayList<>())`)

### 테스트 확인 사항
- [x] Swagger UI에서 챌린지 생성 API 정상 동작 확인
- [x] multipart 요청 시 JSON 데이터와 파일이 모두 정상적으로 전송되는지 확인
- [x] 챌린지 생성 후 `infoImages`, `certImages`가 정상적으로 저장되는지 확인