### PR TITLE
[Feat] 카카오 로그아웃, 탈퇴 기능 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -167,6 +167,7 @@ jobs:
             KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
             KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
             KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
+            KAKAO_ADMIN_KEY=${{ secrets.KAKAO_ADMIN_KEY }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             DB_URL=${{ secrets.PROD_DB_URL }}

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -166,6 +166,7 @@ jobs:
             KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
             KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
             KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
+            KAKAO_ADMIN_KEY=${{ secrets.KAKAO_ADMIN_KEY }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             DB_URL=${{ secrets.STAGE_DB_URL }}

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,12 @@ repositories {
   mavenCentral()
 }
 
+dependencyManagement {
+  imports {
+    mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.0"
+  }
+}
+
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -54,6 +60,9 @@ dependencies {
 
   // Swagger/OpenAPI 3
   implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
+
+  // Feign Client
+  implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/BeilsangServerV2Application.java
@@ -3,11 +3,13 @@ package site.beilsang.beilsang_server_v2;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableScheduling
+@EnableFeignClients
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class BeilsangServerV2Application {
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/controller/OAuthController.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberLoginResDTO;
 import site.beilsang.beilsang_server_v2.domain.oauth.dto.req.AppleLoginReqDto;
 import site.beilsang.beilsang_server_v2.domain.oauth.service.OAuthService;
 import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
-import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 
 @Slf4j
 @RestController
@@ -58,12 +58,23 @@ public class OAuthController {
         )
     )
     @PostMapping("/login/apple")
-    public BaseResponse<BaseResponse<MemberLoginResDTO>> appleLogin(@RequestBody AppleLoginReqDto request) {
-        try {
-            return new BaseResponse<>(oAuthService.loginWithApple(request));
-        } catch (Exception e) {
-            log.error("Apple login failed", e);
-            return new BaseResponse<>(BaseResponseCode.BAD_REQUEST);
-        }
+    public BaseResponse<MemberLoginResDTO> LoginWithApple(@RequestBody AppleLoginReqDto request) {
+        return new BaseResponse<>(oAuthService.loginWithApple(request));
+    }
+
+    @PostMapping("/logout/kakao")
+    public BaseResponse<Void> logoutWithKakao(
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        oAuthService.logoutWithKakao(memberId);
+        return new BaseResponse<>();
+    }
+
+    @PostMapping("/unlink/kakao")
+    public BaseResponse<Void> unlink(
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        oAuthService.unlinkWithKakao(memberId);
+        return new BaseResponse<>();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/controller/OAuthController.java
@@ -58,10 +58,38 @@ public class OAuthController {
         )
     )
     @PostMapping("/login/apple")
-    public BaseResponse<MemberLoginResDTO> LoginWithApple(@RequestBody AppleLoginReqDto request) {
+    public BaseResponse<MemberLoginResDTO> loginWithApple(@RequestBody AppleLoginReqDto request) {
         return new BaseResponse<>(oAuthService.loginWithApple(request));
     }
 
+    @Operation(
+        summary = "카카오 로그아웃",
+        description = """
+        사용자를 카카오 계정에서 로그아웃 처리합니다.
+
+        - 서버에 저장된 Refresh Token을 제거하여 재로그인을 요구합니다.
+        - Kakao API(`/v1/user/logout`)를 호출하여 카카오 서버에서도 로그아웃이 처리됩니다.
+        - Access Token은 클라이언트 단에서 제거해야 합니다.
+        """
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "카카오 로그아웃 성공",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = BaseResponse.class),
+            examples = @ExampleObject(
+                name = "카카오 로그아웃 성공 예시",
+                value = """
+                {
+                  "isSuccess": true,
+                  "code": "200",
+                  "message": "요청에 성공하였습니다."
+                }
+                """
+            )
+        )
+    )
     @PostMapping("/logout/kakao")
     public BaseResponse<Void> logoutWithKakao(
         Authentication authentication) {
@@ -69,9 +97,36 @@ public class OAuthController {
         oAuthService.logoutWithKakao(memberId);
         return new BaseResponse<>();
     }
+    @Operation(
+        summary = "카카오 연동 해제(탈퇴)",
+        description = """
+        사용자의 카카오 계정을 서비스와 완전히 연동 해제합니다.
 
+        - Kakao API(`/v1/user/unlink`) 호출로 카카오 측에서 서비스 연결이 제거됩니다.
+        - 서버에서는 회원의 provider 정보 및 socialId 기반으로 처리합니다.
+        - 이 작업은 돌이킬 수 없으며, 사용자가 다시 카카오 로그인이 필요합니다.
+        """
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "카카오 탈퇴(연동 해제) 성공",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = BaseResponse.class),
+            examples = @ExampleObject(
+                name = "카카오 탈퇴 성공 예시",
+                value = """
+                {
+                  "isSuccess": true,
+                  "code": "200",
+                  "message": "요청에 성공하였습니다."
+                }
+                """
+            )
+        )
+    )
     @PostMapping("/unlink/kakao")
-    public BaseResponse<Void> unlink(
+    public BaseResponse<Void> unlinkWithKakao(
         Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
         oAuthService.unlinkWithKakao(memberId);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/service/OAuthService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/service/OAuthService.java
@@ -1,20 +1,25 @@
 package site.beilsang.beilsang_server_v2.domain.oauth.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import site.beilsang.beilsang_server_v2.domain.member.dto.MemberAssembler;
 import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberLoginResDTO;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
 import site.beilsang.beilsang_server_v2.domain.oauth.dto.req.AppleLoginReqDto;
-import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.enums.Provider;
 import site.beilsang.beilsang_server_v2.global.config.AppleTokenConfig;
+import site.beilsang.beilsang_server_v2.global.feign.KakaoUnlinkClient;
 import site.beilsang.beilsang_server_v2.global.jwt.JwtTokenProvider;
 import site.beilsang.beilsang_server_v2.global.oauth.dto.OAuthAttributes;
 
 import java.util.Map;
+
+import static site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +29,16 @@ public class OAuthService {
     private final MemberRepository memberRepository;
     private final AppleTokenConfig appleTokenConfig;
     private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoUnlinkClient kakaoUnlinkClient;
 
-    public BaseResponse<MemberLoginResDTO> loginWithApple(AppleLoginReqDto request) {
+    private static final String KAKAO_PREFIX = "KakaoAK ";
+    private static final String KAKAO_TARGET_TYPE = "user_id";
+
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
+
+    @Transactional
+    public MemberLoginResDTO loginWithApple(AppleLoginReqDto request) {
 
         log.info("Apple login request received with identityToken");
 
@@ -48,7 +61,7 @@ public class OAuthService {
         MemberLoginResDTO response = MemberAssembler.toMemberLoginResDTO(accessToken, refreshToken, isExistMember);
 
         log.info("Apple login successful for user: {}", member.getSocialId());
-        return new BaseResponse<>(response);
+        return response;
     }
 
     private MemberResult getOrCreateMember(OAuthAttributes attributes) {
@@ -62,6 +75,53 @@ public class OAuthService {
             Member newMember = MemberAssembler.toEntity(Provider.APPLE, attributes.getOAuth2UserInfo());
             return new MemberResult(memberRepository.save(newMember), false);
         });
+    }
+
+    @Transactional
+    public void logoutWithKakao(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+        try {
+            // 카카오 로그아웃
+            kakaoUnlinkClient.logoutUser(
+                KAKAO_PREFIX + kakaoAdminKey, KAKAO_TARGET_TYPE,
+                Long.valueOf(member.getSocialId())
+            );
+
+            // 리프레시 토큰 초기화
+            member.setRefreshToken(null);
+            memberRepository.save(member);
+            log.info("Kakao account successfully logged out: {}", member.getSocialId());
+
+        } catch (Exception e) {
+            log.error("Failed to logout Kakao account", e);
+            throw new BaseException(KAKAO_LOGOUT_FAILED);
+        }
+    }
+
+    @Transactional
+    public void unlinkWithKakao(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+        try {
+            // 카카오 연결 해제
+            kakaoUnlinkClient.unlinkUser(
+                KAKAO_PREFIX + kakaoAdminKey, KAKAO_TARGET_TYPE,
+                Long.valueOf(member.getSocialId())
+            );
+
+            // 회원 삭제
+            memberRepository.delete(member);
+            log.info("Member successfully deleted: {}", member.getSocialId());
+
+        } catch (Exception e) {
+            log.error("Failed to unlink Kakao account", e);
+            throw new BaseException(KAKAO_UNLINK_FAILED);
+        }
+
+        // 연동 해제 후 회원 탈퇴 처리
+        memberRepository.delete(member);
+        log.info("Member deleted: {}", member.getSocialId());
     }
 
     // Member와 isExisting을 함께 반환하는 record 클래스

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/service/OAuthService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/service/OAuthService.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.oauth.service;
 
+import feign.FeignException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,16 +82,20 @@ public class OAuthService {
     public void logoutWithKakao(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+        if (!Provider.KAKAO.equals(member.getProvider())) {
+            throw new BaseException(INVALID_PROVIDER);
+        }
+
         try {
+            // 리프레시 토큰 초기화
+            member.setRefreshToken(null);
+            memberRepository.flush();
+
             // 카카오 로그아웃
             kakaoUnlinkClient.logoutUser(
                 KAKAO_PREFIX + kakaoAdminKey, KAKAO_TARGET_TYPE,
                 Long.valueOf(member.getSocialId())
             );
-
-            // 리프레시 토큰 초기화
-            member.setRefreshToken(null);
-            memberRepository.save(member);
             log.info("Kakao account successfully logged out: {}", member.getSocialId());
 
         } catch (Exception e) {
@@ -103,20 +108,22 @@ public class OAuthService {
     public void unlinkWithKakao(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+        if (!Provider.KAKAO.equals(member.getProvider())) {
+            throw new BaseException(INVALID_PROVIDER);
+        }
         try {
             // 카카오 연결 해제
             kakaoUnlinkClient.unlinkUser(
                 KAKAO_PREFIX + kakaoAdminKey, KAKAO_TARGET_TYPE,
                 Long.valueOf(member.getSocialId())
             );
-
-            // 회원 삭제
-            memberRepository.delete(member);
-            log.info("Member successfully deleted: {}", member.getSocialId());
-
+        } catch (FeignException e) {
+            // 카카오 API 연동 실패
+            log.error("Kakao unlink failed: {}", e.contentUTF8());
+            throw new BaseException(KAKAO_UNLINK_FAILED);
         } catch (Exception e) {
             log.error("Failed to unlink Kakao account", e);
-            throw new BaseException(KAKAO_UNLINK_FAILED);
+            throw new BaseException(INTERNAL_SERVER_ERROR);
         }
 
         // 연동 해제 후 회원 탈퇴 처리
@@ -125,5 +132,6 @@ public class OAuthService {
     }
 
     // Member와 isExisting을 함께 반환하는 record 클래스
-    private record MemberResult(Member member, boolean isExist) {}
+    private record MemberResult(Member member, boolean isExist) {
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -17,13 +17,15 @@ public enum BaseResponseCode {
     NULL_REQUEST_PARAM(HttpStatus.BAD_REQUEST, "GL002", "쿼리 파라미터가 없습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "GL003", "잘못된 요청입니다."),
     CONTENT_NULL(HttpStatus.BAD_REQUEST, "GL004", "내용을 입력해 주세요."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GL005", "서버 내부 오류입니다."),
 
     //oauth
-    EXPIRED_JWT(HttpStatus.BAD_REQUEST, "O0001", "토큰이 만료되었습니다"),
-    INVALID_JWT(HttpStatus.BAD_REQUEST, "O0002", "유효하지 않은 토큰입니다"),
-    NOT_FOUND_JWT(HttpStatus.BAD_REQUEST, "O0003", "토큰이 존재하지 않습니다"),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "O0001", "토큰이 만료되었습니다"),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "O0002", "유효하지 않은 토큰입니다"),
+    NOT_FOUND_JWT(HttpStatus.UNAUTHORIZED, "O0003", "토큰이 존재하지 않습니다"),
     KAKAO_LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "O0004", "카카오 로그아웃에 실패했습니다"),
     KAKAO_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "O0005", "카카오 연결 해제에 실패했습니다"),
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "O0006", "유효하지 않은 소셜 로그인 제공자입니다"),
 
 
     // member

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -18,6 +18,14 @@ public enum BaseResponseCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "GL003", "잘못된 요청입니다."),
     CONTENT_NULL(HttpStatus.BAD_REQUEST, "GL004", "내용을 입력해 주세요."),
 
+    //oauth
+    EXPIRED_JWT(HttpStatus.BAD_REQUEST, "O0001", "토큰이 만료되었습니다"),
+    INVALID_JWT(HttpStatus.BAD_REQUEST, "O0002", "유효하지 않은 토큰입니다"),
+    NOT_FOUND_JWT(HttpStatus.BAD_REQUEST, "O0003", "토큰이 존재하지 않습니다"),
+    KAKAO_LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "O0004", "카카오 로그아웃에 실패했습니다"),
+    KAKAO_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "O0005", "카카오 연결 해제에 실패했습니다"),
+
+
     // member
     NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "M0001", "존재하지 않은 멤버입니다"),
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAccessDeniedHandler.java
@@ -19,7 +19,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         AccessDeniedException accessDeniedException) throws IOException, ServletException {
         log.info("[CustomAccessDeniedHandler] :: {}", accessDeniedException.getMessage());
         log.info("[CustomAccessDeniedHandler] :: {}", request.getRequestURL());
-        log.info("[CustomAccessDeniedHandler] :: 토근 정보가 만료되었거나 존재하지 않음");
+        log.info("[CustomAccessDeniedHandler] :: 토큰 정보가 만료되었거나 존재하지 않음");
 
         //TODO - 에러 핸들링
     }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
@@ -25,6 +25,10 @@ public class CustomAuthenticationEntryPointHandler implements AuthenticationEntr
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException {
 
+        log.info("[CustomAccessDeniedHandler] :: {}", authException.getMessage());
+        log.info("[CustomAccessDeniedHandler] :: {}", request.getRequestURL());
+        log.info("[CustomAccessDeniedHandler] :: 토근 정보가 만료되었거나 존재하지 않음");
+
         String exception = (String) request.getAttribute("exception");
         BaseResponseCode errorCode;
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
@@ -27,7 +27,7 @@ public class CustomAuthenticationEntryPointHandler implements AuthenticationEntr
 
         log.info("[CustomAccessDeniedHandler] :: {}", authException.getMessage());
         log.info("[CustomAccessDeniedHandler] :: {}", request.getRequestURL());
-        log.info("[CustomAccessDeniedHandler] :: 토근 정보가 만료되었거나 존재하지 않음");
+        log.info("[CustomAccessDeniedHandler] :: 토큰 정보가 만료되었거나 존재하지 않음");
 
         String exception = (String) request.getAttribute("exception");
         BaseResponseCode errorCode;

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/CustomAuthenticationEntryPointHandler.java
@@ -1,27 +1,57 @@
 package site.beilsang.beilsang_server_v2.global.config;
 
-import jakarta.servlet.ServletException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
     // 인증되지 않은 사용자가 접근 시 동작
 
+    private final ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException authException) throws IOException, ServletException {
-        log.info("[CustomAuthenticationEntryPointHandler] :: {}", authException.getMessage());
-        log.info("[CustomAuthenticationEntryPointHandler] :: {}", request.getRequestURL());
-        log.info("[CustomAuthenticationEntryPointHandler] :: 토큰 정보가 만료되었거나 존재하지 않음");
+        AuthenticationException authException) throws IOException {
 
-        //TODO
+        String exception = (String) request.getAttribute("exception");
+        BaseResponseCode errorCode;
 
+        // ① 예외 분기
+        if ("NO_JWT".equals(exception)) {
+            errorCode = BaseResponseCode.NOT_FOUND_JWT;
+        }
+        else if ("EXPIRED_JWT".equals(exception)) {
+            errorCode = BaseResponseCode.EXPIRED_JWT;
+        }
+        else if ("INVALID_JWT".equals(exception)) {
+            errorCode = BaseResponseCode.INVALID_JWT;
+        }
+        else {
+            errorCode = BaseResponseCode.BAD_REQUEST;
+        }
+
+        // ② 응답 설정
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json; charset=UTF-8");
+
+        // ③ BaseResponse 생성
+        BaseResponse<Object> errorResponse = new BaseResponse<>(errorCode);
+
+        // ④ JSON 변환 후 응답 작성
+        String jsonBody = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonBody);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/SecurityConfig.java
@@ -50,8 +50,8 @@ public class SecurityConfig {
 
         // white list
         MvcRequestMatcher[] permitWhiteList = {
-            mvc.pattern("/oauth/**"),
-            mvc.pattern("/api/oauth/**"),
+            mvc.pattern("/oauth/login/**"),
+            mvc.pattern("/api/oauth/login/**"),
             mvc.pattern("/favicon.ico"),
             mvc.pattern("/error"),
             // Swagger UI 접근 허용

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/feign/KakaoUnlinkClient.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/feign/KakaoUnlinkClient.java
@@ -1,6 +1,5 @@
 package site.beilsang.beilsang_server_v2.global.feign;
 
-
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -13,14 +12,14 @@ public interface KakaoUnlinkClient {
     @PostMapping(value = "/v1/user/logout", consumes = "application/x-www-form-urlencoded")
     void logoutUser(
         @RequestHeader("Authorization") String authorization,
-        @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
+        @RequestParam(name = "target_id_type") String targetIdType,
         @RequestParam("target_id") Long targetId
     );
 
     @PostMapping(value = "/v1/user/unlink", consumes = "application/x-www-form-urlencoded")
     void unlinkUser(
         @RequestHeader("Authorization") String authorization,
-        @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
+        @RequestParam(name = "target_id_type") String targetIdType,
         @RequestParam("target_id") Long targetId
     );
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/feign/KakaoUnlinkClient.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/feign/KakaoUnlinkClient.java
@@ -1,0 +1,26 @@
+package site.beilsang.beilsang_server_v2.global.feign;
+
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+//KakaoUnlinkClient
+@FeignClient(name = "KakaoUnlinkClient", url = "https://kapi.kakao.com")
+public interface KakaoUnlinkClient {
+
+    @PostMapping(value = "/v1/user/logout", consumes = "application/x-www-form-urlencoded")
+    void logoutUser(
+        @RequestHeader("Authorization") String authorization,
+        @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
+        @RequestParam("target_id") Long targetId
+    );
+
+    @PostMapping(value = "/v1/user/unlink", consumes = "application/x-www-form-urlencoded")
+    void unlinkUser(
+        @RequestHeader("Authorization") String authorization,
+        @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
+        @RequestParam("target_id") Long targetId
+    );
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.security.SignatureException;
 import java.util.Collections;
 
 import lombok.RequiredArgsConstructor;
@@ -89,7 +88,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private void setSecurityContextHolder(String token) {
         String socialId = jwtTokenProvider.getClaimFromToken(token, "socialId");
         String email = jwtTokenProvider.getClaimFromToken(token, "email");
-        //TODO
         Member member = memberRepository.findBySocialIdAndEmail(socialId, email)
             .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -33,43 +33,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
-//    @Override
-//    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-//        // HTTP 요청 헤더에서 access token을 추출
-//        String token = extractToken(request);
-//
-////        // access token이 존재하지 않거나 토큰이 유효하지 않으면 401 코드 반환
-////        if (!jwtTokenProvider.validateToken(token) || !StringUtils.hasText(token)) {
-////
-////            //토큰이 없을 경우
-////            doFilter(request, response, filterChain);
-////            return;
-////        }
-////        setSecurityContextHolder(token);
-////        filterChain.doFilter(request, response);
-//        // ① 토큰이 아예 없는 경우
-//        if (!StringUtils.hasText(token)) {
-//            request.setAttribute("exception", "NO_JWT");
-//            filterChain.doFilter(request, response);
-//            return;
-//        }
-//
-//        // ② 토큰이 있는데 검증 실패 (만료, 위조, 포맷 오류)
-//        try {
-//            jwtTokenProvider.validateToken(token);
-//        } catch (ExpiredJwtException e) {
-//            request.setAttribute("exception", "EXPIRED_JWT");
-//            filterChain.doFilter(request, response);
-//        } catch (Exception e) {
-//            request.setAttribute("exception", "INVALID_JWT");
-//            filterChain.doFilter(request, response);
-//            return;
-//        }
-//        // ③ 정상 토큰 → SecurityContext 적용
-//        setSecurityContextHolder(token);
-//        filterChain.doFilter(request, response);
-//    }
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtAuthFilter.java
@@ -1,11 +1,15 @@
 package site.beilsang.beilsang_server_v2.global.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+import java.security.SignatureException;
 import java.util.Collections;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,21 +33,72 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
+//    @Override
+//    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+//        // HTTP 요청 헤더에서 access token을 추출
+//        String token = extractToken(request);
+//
+////        // access token이 존재하지 않거나 토큰이 유효하지 않으면 401 코드 반환
+////        if (!jwtTokenProvider.validateToken(token) || !StringUtils.hasText(token)) {
+////
+////            //토큰이 없을 경우
+////            doFilter(request, response, filterChain);
+////            return;
+////        }
+////        setSecurityContextHolder(token);
+////        filterChain.doFilter(request, response);
+//        // ① 토큰이 아예 없는 경우
+//        if (!StringUtils.hasText(token)) {
+//            request.setAttribute("exception", "NO_JWT");
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
+//
+//        // ② 토큰이 있는데 검증 실패 (만료, 위조, 포맷 오류)
+//        try {
+//            jwtTokenProvider.validateToken(token);
+//        } catch (ExpiredJwtException e) {
+//            request.setAttribute("exception", "EXPIRED_JWT");
+//            filterChain.doFilter(request, response);
+//        } catch (Exception e) {
+//            request.setAttribute("exception", "INVALID_JWT");
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
+//        // ③ 정상 토큰 → SecurityContext 적용
+//        setSecurityContextHolder(token);
+//        filterChain.doFilter(request, response);
+//    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-        FilterChain filterChain) throws ServletException, IOException {
-        // HTTP 요청 헤더에서 access token을 추출
+                                    FilterChain filterChain) throws ServletException, IOException {
         String token = extractToken(request);
 
-        // access token이 존재하지 않거나 토큰이 유효하지 않으면 401 코드 반환
-        if (!jwtTokenProvider.validateToken(token) || !StringUtils.hasText(token)) {
-
-//            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
-            //토큰이 없을 경우
-            doFilter(request, response, filterChain);
+        if (!StringUtils.hasText(token)) {
+            request.setAttribute("exception", "NO_JWT");
+            filterChain.doFilter(request, response);
             return;
         }
-        setSecurityContextHolder(token);
+
+        try {
+            // 토큰 검증
+            jwtTokenProvider.validateToken(token);
+
+            // SecurityContext 설정 (회원이 없으면 설정 안 함)
+            setSecurityContextHolder(token);
+
+        } catch (ExpiredJwtException e) {
+            log.warn("Expired JWT token");
+            request.setAttribute("exception", "EXPIRED_JWT");
+        } catch (BaseException e) {
+            log.warn("Member not found (deleted): {}", e.getMessage());
+            request.setAttribute("exception", "MEMBER_DELETED");
+        } catch (Exception e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            request.setAttribute("exception", "INVALID_JWT");
+        }
+
         filterChain.doFilter(request, response);
     }
 
@@ -78,7 +133,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // 인증 토큰을 받아 SecurityContext에 저장
         SecurityContextHolder.getContext().setAuthentication(getUserAuth(member));
     }
-
     /**
      * 멤버 정보를 바탕으로 인증 토큰 생성, Controller에서 Authentication.getPrincipal로 값 받아올 수 있음
      *
@@ -86,10 +140,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
      * @return UsernamePasswordAuthenticationToken
      */
     private UsernamePasswordAuthenticationToken getUserAuth(Member member) {
-        return new UsernamePasswordAuthenticationToken(
-            member.getId(), //member가 아닌 memberId를 넣어 최소한의 정보만 갖도록 설정
-            member.getSocialId(),
-            Collections.singleton(new SimpleGrantedAuthority(Role.USER.getRole()))
-        );
+        return new UsernamePasswordAuthenticationToken(member.getId(), //member가 아닌 memberId를 넣어 최소한의 정보만 갖도록 설정
+            member.getSocialId(), Collections.singleton(new SimpleGrantedAuthority(Role.USER.getRole())));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/jwt/JwtTokenProvider.java
@@ -97,16 +97,11 @@ public class JwtTokenProvider {
      *
      * @param token
      */
-    public Boolean validateToken(String token) {
-        try {
-            Jws<Claims> claimsJws = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token);
-            return !claimsJws.getBody().getExpiration().before(new Date());
-        } catch (JwtException | IllegalArgumentException exception) {
-            return false;
-        }
+    public void validateToken(String token) {
+        Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token);
     }
 
     /**

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,17 +1,18 @@
 package site.beilsang.beilsang_server_v2.global.oauth.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.jwt.JwtTokenProvider;
 import site.beilsang.beilsang_server_v2.global.oauth.CustomOAuth2User;
+
+import static site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode.BAD_REQUEST;
 
 @Slf4j
 @Component
@@ -22,7 +23,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) throws IOException, ServletException {
+        Authentication authentication) {
         log.info("OAuth2LoginSuccessHandler 로그인 성공");
 
         try {
@@ -30,7 +31,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             SecurityContextHolder.getContext().setAuthentication(authentication);
             jwtTokenProvider.sendToken(response, oAuth2User);
         } catch (Exception e) {
-
+            throw new BaseException(BAD_REQUEST);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,9 @@ apple:
   team-id: ${APPLE_TEAM_ID}
   private-key-path: ${APPLE_PRIVATE_KEY_PATH}
 
+kakao:
+    admin-key: ${KAKAO_ADMIN_KEY}
+
 # Swagger/OpenAPI 설정
 springdoc:
   api-docs:


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- closed #65 

## 🍬 기능 설명
- 카카오 로그인에 대한 로그아웃, 탈퇴 기능을 추가했습니다.
- OpenFeign 라이브러리를 사용해 카카오에 요청보내는 코드를 간편화했습니다.
- 로그인 관련 Return 설명을 세분화했습니다.
- 탈퇴의 경우 아래와 같은 두 방식이 있지만, 첫 번째의 경우 탈퇴를 위해선 다시 로그인 후 탈퇴 요청해야한다는 불편함이 있다고 하여 
2번을 선택했습니다.
  1. 카카오 액세스 토큰 방식으로 연결을 끊기
  2. 앱 어드민 키를 사용하여 연결 끊기

## 🤔 코드 리뷰에서 집중적으로 볼 내용
<!-- 코드를 작성하면서 헷갈렸던 부분을 캡처/복사해서 넣자 -->
OpenFeign에 사용되는 인터페이스입니다. logoutUser로 보시면 FeignClient의 url + value에 해당하는 주소로 post하는 것을 도와줍니다.
파일 위치를 `global/feign/KakaoUnlinkClient`로 따로 뺐는데 다른 의견 있으시면 말씀해주세요
```java
//KakaoUnlinkClient
@FeignClient(name = "KakaoUnlinkClient", url = "https://kapi.kakao.com")
public interface KakaoUnlinkClient {

    @PostMapping(value = "/v1/user/logout", consumes = "application/x-www-form-urlencoded")
    void logoutUser(
        @RequestHeader("Authorization") String authorization,
        @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
        @RequestParam("target_id") Long targetId
    );

    @PostMapping(value = "/v1/user/unlink", consumes = "application/x-www-form-urlencoded")
    void unlinkUser(
        @RequestHeader("Authorization") String authorization,
        @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
        @RequestParam("target_id") Long targetId
    );
}
```

## ⭐ 기타 사항
<!-- 개발할 때 참고했던 레퍼런스나 공유하면 좋을 것들을 나눠보아요 -->
**OpenFeign 참고**
https://sssbin.tistory.com/263
