### PR TITLE
[Fix] 챌린지 생성 오류

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -18,6 +18,9 @@ server {
     ssl_certificate /etc/letsencrypt/live/stage.beilsang.site/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/stage.beilsang.site/privkey.pem;
 
+    # 파일 업로드 크기 제한 (챌린지 이미지 업로드용)
+    client_max_body_size 3m;
+
     location / {
         proxy_pass http://beilsang-server:8080; #beilsang-server는 도커 컴포즈 서비스 이름
         proxy_set_header Host $host;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/CreateChallengeReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/CreateChallengeReqDTO.java
@@ -14,7 +14,7 @@ public class CreateChallengeReqDTO {
     @Schema(description = "챌린지 제목", example = "매일 물 8잔 마시기")
     private String title;
 
-    @Schema(description = "챌린지 시작 날짜", example = "2024-01-01")
+    @Schema(description = "챌린지 시작 날짜", example = "2025-12-20")
     private LocalDate startDate;
 
     @Schema(description = "챌린지 기간", example = "WEEK")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
       region:
         static: ap-northeast-2
       s3:
-        bucket: beilsang-bucket-dev
+        bucket: beilsang-bucket-stage
         path:
           challenge-main: challenge/main/
           challenge-cert: challenge/cert/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     name: beilsang-server-v2
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local-mysql} # 배포시 github actions에서 환경변수로 stage/prod 설정
+  servlet:
+    multipart:
+      max-file-size: 3MB # 파일당 최대 크기
+      max-request-size: 15MB # 전체 요청 최대 크기 (여러 파일 업로드 고려)
   security:
     oauth2: # OAuth
       client:


### PR DESCRIPTION
## **📌 이슈 번호**

- closed #70
## **🍬 기능 설명**

- 챌린지 이미지 업로드 시 발생하던 413 Request Entity Too Large 오류 해결
- nginx와 Spring Boot에 파일 업로드 크기 제한 설정 추가
- AWS S3 버킷 생성 및 액세스 키 재발급

## **🤔 코드 리뷰에서 집중적으로 볼 내용**

### **1. nginx 설정 (nginx/conf.d/default.conf)**

`# 파일 업로드 크기 제한 (챌린지 이미지 업로드용)
client_max_body_size 3m;`

- nginx에서 3MB로 제한 설정
- 이 설정이 없으면 기본값 1MB로 제한되어 413 오류 발생

### **2. Spring Boot 설정 (application.yml)**

`servlet:
  multipart:
    max-file-size: 3MB # 파일당 최대 크기
    max-request-size: 15MB # 전체 요청 최대 크기 (여러 파일 업로드 고려)`

- 파일당 3MB, 전체 요청 15MB로 설정
- 챌린지 생성 시 여러 이미지를 업로드하므로 전체 요청 크기를 충분히 설정

## **⭐ 기타 사항**

### **문제 해결 과정**

1. **초기 증상**: 챌린지 생성 시 413 Request Entity Too Large 오류 (nginx)
2. **1차 해결**: nginx client_max_body_size와 Spring Boot multipart 설정 추가
3. **2차 문제**: 환경변수 설정 후 테스트 중 S3 버킷 미생성 발견
4. **최종 해결**: AWS에서 S3 버킷 생성 및 액세스 키/시크릿 키 재발급

### **참고**

- 일반적인 이미지 업로드 크기 제한: 3~5MB (모바일 사진 기준)
- 현재 설정: 파일당 3MB, 전체 요청 15MB (챌린지 생성 시 여러 이미지 업로드 고려)
- 문서(노션), 깃허브 액션 환경 변수 수정함