### PR TITLE
[Feat] 챌린지 찜하기 기능 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -97,5 +98,37 @@ public class ChallengeController {
         Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.joinChallenge(challengeId, memberId));
+    }
+
+    @Operation(summary = "챌린지 찜하기", description = "특정 챌린지를 찜합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "챌린지 찜하기 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 찜한 챌린지"),
+        @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @PostMapping("/{challengeId}/like")
+    public BaseResponse<Void> likeChallenge(
+        @Parameter(description = "찜할 챌린지 ID", example = "1") @PathVariable Long challengeId,
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        challengeService.likeChallenge(challengeId, memberId);
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "챌린지 찜 취소", description = "특정 챌린지의 찜을 취소합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "챌린지 찜 취소 성공"),
+        @ApiResponse(responseCode = "400", description = "찜하지 않은 챌린지"),
+        @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @DeleteMapping("/{challengeId}/like")
+    public BaseResponse<Void> unlikeChallenge(
+        @Parameter(description = "찜 취소할 챌린지 ID", example = "1") @PathVariable Long challengeId,
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        challengeService.unlikeChallenge(challengeId, memberId);
+        return new BaseResponse<>();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -88,8 +88,8 @@ public class ChallengeAssembler {
     }
 
     public static ChallengeDetailResDTO toChallengeDetailResDTO(
-        Challenge challenge, boolean isJoinable, ChallengeMemberStatus status, Float progress,
-        Integer usedPoint, Integer earnedPoint
+        Challenge challenge, boolean isJoinable, boolean isLiked, ChallengeMemberStatus status,
+        Float progress, Integer usedPoint, Integer earnedPoint
     ) {
         List<String> infoImageUrls = challenge.getInfoImages().stream()
             .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
@@ -117,6 +117,7 @@ public class ChallengeAssembler {
             .joinPoint(challenge.getJoinPoint())
             .attendeeCount(challenge.getAttendeeCount())
             .likeCount(challenge.getCountLikes())
+            .isLiked(isLiked)
             .infoImageUrls(infoImageUrls)
             .certImageUrls(certImageUrls)
             .challengeNotes(challengeNotes)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -22,6 +22,7 @@ public class ChallengeDetailResDTO {
     private Integer joinPoint;
     private Integer attendeeCount;
     private Integer likeCount;
+    private Boolean isLiked; // 현재 사용자가 찜했는지 여부
     private List<String> infoImageUrls;
     private List<String> certImageUrls;
     private List<String> challengeNotes;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -107,4 +107,20 @@ public class Challenge extends BaseEntity {
     public void incrementAttendeeCount() {
         this.attendeeCount++;
     }
+
+    /**
+     * 챌린지 찜 수 증가
+     */
+    public void incrementLikeCount() {
+        this.countLikes++;
+    }
+
+    /**
+     * 챌린지 찜 수 감소
+     */
+    public void decrementLikeCount() {
+        if (this.countLikes > 0) {
+            this.countLikes--;
+        }
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -52,4 +52,20 @@ public interface ChallengeService {
      * @return 챌린지 참여 결과
      */
     JoinChallengeResDTO joinChallenge(Long challengeId, Long memberId);
+
+    /**
+     * 챌린지를 찜합니다.
+     *
+     * @param challengeId 찜할 챌린지 ID
+     * @param memberId    찜하는 회원 ID
+     */
+    void likeChallenge(Long challengeId, Long memberId);
+
+    /**
+     * 챌린지 찜을 취소합니다.
+     *
+     * @param challengeId 찜 취소할 챌린지 ID
+     * @param memberId    찜 취소하는 회원 ID
+     */
+    void unlikeChallenge(Long challengeId, Long memberId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -25,6 +25,8 @@ import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeInfoIma
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.ChallengeNote;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeNoteRepository;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
+import site.beilsang.beilsang_server_v2.domain.like.entity.ChallengeLike;
+import site.beilsang.beilsang_server_v2.domain.like.repository.ChallengeLikeRepository;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMemberRepository;
@@ -56,6 +58,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeMemberRepository challengeMemberRepository;
     private final ChallengeNoteRepository challengeNoteRepository;
+    private final ChallengeLikeRepository challengeLikeRepository;
     private final PointLogRepository pointLogRepository;
     private final PointService pointService;
     private final S3Service s3Service;
@@ -220,6 +223,9 @@ public class ChallengeServiceImpl implements ChallengeService {
         boolean isJoinable =
             challengeMemberOpt.isEmpty() && challenge.getStatus() != ChallengeStatus.END;
 
+        // 찜 여부 확인
+        boolean isLiked = challengeLikeRepository.existsByMemberIdAndChallengeId(memberId, challengeId);
+
         // 챌린지 상태
         ChallengeMemberStatus status = challengeMemberOpt
             .map(ChallengeMember::getChallengeMemberStatus)
@@ -244,7 +250,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         }
 
         return ChallengeAssembler.toChallengeDetailResDTO(
-            challenge, isJoinable, status, progress, usedPoint, earnedPoint
+            challenge, isJoinable, isLiked, status, progress, usedPoint, earnedPoint
         );
     }
 
@@ -320,5 +326,52 @@ public class ChallengeServiceImpl implements ChallengeService {
             .filter(pointLog -> pointLog.getStatus() == targetStatus)
             .mapToInt(PointLog::getPoints)
             .sum();
+    }
+
+    @Override
+    public void likeChallenge(Long challengeId, Long memberId) {
+        // 챌린지 존재 확인
+        Challenge challenge = challengeRepository.findById(challengeId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE));
+
+        // 회원 존재 확인
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        // 이미 찜한 챌린지인지 확인
+        if (challengeLikeRepository.existsByMemberIdAndChallengeId(memberId, challengeId)) {
+            throw new BaseException(BaseResponseCode.ALREADY_LIKED_CHALLENGE);
+        }
+
+        // ChallengeLike 엔티티 생성 및 저장
+        ChallengeLike challengeLike = ChallengeLike.builder()
+            .member(member)
+            .challenge(challenge)
+            .build();
+        challengeLikeRepository.save(challengeLike);
+
+        // 챌린지 찜 수 증가
+        challenge.incrementLikeCount();
+    }
+
+    @Override
+    public void unlikeChallenge(Long challengeId, Long memberId) {
+        // 챌린지 존재 확인
+        Challenge challenge = challengeRepository.findById(challengeId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE));
+
+        // 회원 존재 확인
+        memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        // 찜한 기록 조회
+        ChallengeLike challengeLike = challengeLikeRepository.findByMemberIdAndChallengeId(memberId, challengeId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_LIKED_CHALLENGE));
+
+        // ChallengeLike 엔티티 삭제
+        challengeLikeRepository.delete(challengeLike);
+
+        // 챌린지 찜 수 감소
+        challenge.decrementLikeCount();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/like/repository/ChallengeLikeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/like/repository/ChallengeLikeRepository.java
@@ -1,9 +1,31 @@
 package site.beilsang.beilsang_server_v2.domain.like.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.like.entity.ChallengeLike;
 
 public interface ChallengeLikeRepository extends JpaRepository<ChallengeLike, Long> {
 
+    /**
+     * 회원 ID로 찜한 챌린지 수 조회
+     * @param memberId 회원 ID
+     * @return 찜한 챌린지 수
+     */
     Long countByMemberId(Long memberId);
+
+    /**
+     * 회원이 특정 챌린지를 찜했는지 확인
+     * @param memberId 회원 ID
+     * @param challengeId 챌린지 ID
+     * @return 찜 여부
+     */
+    boolean existsByMemberIdAndChallengeId(Long memberId, Long challengeId);
+
+    /**
+     * 회원과 챌린지로 찜 엔티티 조회
+     * @param memberId 회원 ID
+     * @param challengeId 챌린지 ID
+     * @return 찜 엔티티 Optional
+     */
+    Optional<ChallengeLike> findByMemberIdAndChallengeId(Long memberId, Long challengeId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -45,7 +45,9 @@ public enum BaseResponseCode {
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "C0003", "시작 날짜는 오늘 이후여야 합니다"),
     NOT_FOUND_CHALLENGE(HttpStatus.BAD_REQUEST, "C0004", "존재하지 않는 챌린지입니다"),
     ALREADY_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0005", "이미 참여한 챌린지입니다"),
-    CHALLENGE_ENDED(HttpStatus.BAD_REQUEST, "C0006", "종료된 챌린지입니다");
+    CHALLENGE_ENDED(HttpStatus.BAD_REQUEST, "C0006", "종료된 챌린지입니다"),
+    ALREADY_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0007", "이미 찜한 챌린지입니다"),
+    NOT_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0008", "찜하지 않은 챌린지입니다");
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드


### PR DESCRIPTION
## 📌 이슈 번호
- closed #82 

## 🍬 기능 설명
- 챌린지 상세조회 시 현재 사용자가 해당 챌린지를 찜했는지 여부를 확인할 수 있습니다
- 찜하지 않은 챌린지를 찜할 수 있는 API를 추가했습니다
- 찜한 챌린지의 찜을 취소할 수 있는 API를 추가했습니다
- 찜 수는 실시간으로 증감됩니다

## 🤔 코드 리뷰에서 집중적으로 볼 내용

### 1. 트랜잭션 처리
`ChallengeServiceImpl`의 `likeChallenge`와 `unlikeChallenge` 메서드는 `@Transactional` 어노테이션이 클래스 레벨에 선언되어 있어 자동으로 트랜잭션이 적용됩니다.

- 찜하기: `ChallengeLike` 엔티티 저장 + `Challenge`의 `countLikes` 증가
- 찜 취소: `ChallengeLike` 엔티티 삭제 + `Challenge`의 `countLikes` 감소

두 작업이 하나의 트랜잭션으로 묶여 데이터 일관성이 보장됩니다.

### 2. Challenge 엔티티의 찜 수 감소 로직
```java
public void decrementLikeCount() {
    if (this.countLikes > 0) {
        this.countLikes--;
    }
}
```
찜 수가 0 이하로 내려가지 않도록 검증 로직을 추가했습니다.

### 3. 중복 찜 방지
`existsByMemberIdAndChallengeId`를 사용하여 이미 찜한 챌린지인지 확인하고, 중복 찜 시 `ALREADY_LIKED_CHALLENGE` 예외를 발생시킵니다.

### 4. API 설계
- `POST /challenge/{challengeId}/like`: 찜하기
- `DELETE /challenge/{challengeId}/like`: 찜 취소
- RESTful API 설계 원칙에 따라 같은 리소스(`/like`)에 대해 HTTP 메서드(POST/DELETE)로 구분했습니다.

### 5. 챌린지 상세 조회 응답에 찜 여부 추가
`ChallengeDetailResDTO`에 `isLiked` 필드를 추가하여 현재 사용자가 해당 챌린지를 찜했는지 여부를 반환합니다.

## ⭐ 기타 사항
- 기존 `ChallengeLike` 엔티티를 활용하여 구현했습니다
- 새로운 예외 코드 추가:
  - `ALREADY_LIKED_CHALLENGE` (C0007): 이미 찜한 챌린지
  - `NOT_LIKED_CHALLENGE` (C0008): 찜하지 않은 챌린지
- Swagger 문서화 완료
