### PR TITLE
[Feat] 챌린지 검색 기능 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
@@ -97,5 +98,39 @@ public class ChallengeController {
         Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.joinChallenge(challengeId, memberId));
+    }
+
+    /**
+     * 모집 마감된 챌린지 검색
+     * - 시작일이 오늘 이전인 챌린지를 검색
+     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
+     */
+    @Operation(summary = "모집 마감 챌린지 검색",
+        description = "모집이 마감된 챌린지를 제목으로 검색합니다. 오늘 날짜에 가까운 챌린지부터 표시됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/search/closed")
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> searchClosedChallenges(
+        @Parameter(description = "챌린지 검색 조건") @ModelAttribute SearchChallengeReqDTO requestDTO) {
+        return new BaseResponse<>(challengeService.searchClosedChallenges(requestDTO));
+    }
+
+    /**
+     * 모집 중인 챌린지 검색
+     * - 시작일이 오늘 이후인 챌린지를 검색
+     * - 정렬 옵션: 마감 임박순(DEADLINE_SOON) / 최신순(NEWEST)
+     */
+    @Operation(summary = "모집 중인 챌린지 검색",
+        description = "현재 모집 중인 챌린지를 제목으로 검색합니다. 마감 임박순 또는 최신순으로 정렬할 수 있습니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/search/open")
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> searchOpenChallenges(
+        @Parameter(description = "챌린지 검색 조건") @ModelAttribute SearchChallengeReqDTO requestDTO) {
+        return new BaseResponse<>(challengeService.searchOpenChallenges(requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -132,6 +132,7 @@ public class ChallengeController {
         Long memberId = (Long) authentication.getPrincipal();
         challengeService.unlikeChallenge(challengeId, memberId);
         return new BaseResponse<>();
+    }
 
     @Operation(summary = "모집 마감 챌린지 검색",
         description = "모집이 마감된 챌린지를 제목으로 검색합니다. 오늘 날짜에 가까운 챌린지부터 표시됩니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -21,7 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
@@ -100,11 +101,6 @@ public class ChallengeController {
         return new BaseResponse<>(challengeService.joinChallenge(challengeId, memberId));
     }
 
-    /**
-     * 모집 마감된 챌린지 검색
-     * - 시작일이 오늘 이전인 챌린지를 검색
-     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
-     */
     @Operation(summary = "모집 마감 챌린지 검색",
         description = "모집이 마감된 챌린지를 제목으로 검색합니다. 오늘 날짜에 가까운 챌린지부터 표시됩니다.")
     @ApiResponses(value = {
@@ -113,15 +109,10 @@ public class ChallengeController {
     })
     @GetMapping("/search/closed")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> searchClosedChallenges(
-        @Parameter(description = "챌린지 검색 조건") @ModelAttribute SearchChallengeReqDTO requestDTO) {
+        @Parameter(description = "모집 마감 챌린지 검색 조건") @ModelAttribute SearchClosedChallengeReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.searchClosedChallenges(requestDTO));
     }
 
-    /**
-     * 모집 중인 챌린지 검색
-     * - 시작일이 오늘 이후인 챌린지를 검색
-     * - 정렬 옵션: 마감 임박순(DEADLINE_SOON) / 최신순(NEWEST)
-     */
     @Operation(summary = "모집 중인 챌린지 검색",
         description = "현재 모집 중인 챌린지를 제목으로 검색합니다. 마감 임박순 또는 최신순으로 정렬할 수 있습니다.")
     @ApiResponses(value = {
@@ -130,7 +121,7 @@ public class ChallengeController {
     })
     @GetMapping("/search/open")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> searchOpenChallenges(
-        @Parameter(description = "챌린지 검색 조건") @ModelAttribute SearchChallengeReqDTO requestDTO) {
+        @Parameter(description = "모집 중인 챌린지 검색 조건") @ModelAttribute SearchOpenChallengeReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.searchOpenChallenges(requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchChallengeReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchChallengeReqDTO.java
@@ -1,0 +1,26 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
+
+/**
+ * 챌린지 검색 요청 DTO
+ * - 모집 마감/모집 중 챌린지 검색 시 사용
+ */
+@Getter
+@Setter
+public class SearchChallengeReqDTO {
+
+    // 검색 키워드 (챌린지 제목 검색)
+    private String keyword;
+
+    // 정렬 타입 (모집 중인 챌린지 검색 시 사용, 기본값: 마감 임박순)
+    private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
+
+    // 페이지 번호 (0부터 시작, 기본값: 0)
+    private Integer page = 0;
+
+    // 페이지 크기 (기본값: 10)
+    private Integer size = 10;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchChallengeReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchChallengeReqDTO.java
@@ -1,26 +1,34 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 
 /**
- * 챌린지 검색 요청 DTO
- * - 모집 마감/모집 중 챌린지 검색 시 사용
+ * 챌린지 검색 요청 DTO - 모집 마감/모집 중 챌린지 검색 시 사용
  */
+@Schema(description = "챌린지 검색 요청 DTO")
 @Getter
 @Setter
 public class SearchChallengeReqDTO {
 
-    // 검색 키워드 (챌린지 제목 검색)
+    @Schema(description = "검색 키워드 (챌린지 제목 검색)", example = "플로깅")
     private String keyword;
 
-    // 정렬 타입 (모집 중인 챌린지 검색 시 사용, 기본값: 마감 임박순)
+    @Schema(description = "정렬 타입 (모집 중인 챌린지 검색 시 사용)",
+        example = "DEADLINE_SOON",
+        allowableValues = {"DEADLINE_SOON", "NEWEST"})
     private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
 
-    // 페이지 번호 (0부터 시작, 기본값: 0)
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
     private Integer page = 0;
 
-    // 페이지 크기 (기본값: 10)
+    @Schema(description = "페이지 크기", example = "10", minimum = "1", maximum = "100")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
     private Integer size = 10;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchClosedChallengeReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchClosedChallengeReqDTO.java
@@ -5,23 +5,14 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
-import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 
-/**
- * 챌린지 검색 요청 DTO - 모집 마감/모집 중 챌린지 검색 시 사용
- */
-@Schema(description = "챌린지 검색 요청 DTO")
+@Schema(description = "모집 마감 챌린지 검색 요청 DTO")
 @Getter
 @Setter
-public class SearchChallengeReqDTO {
+public class SearchClosedChallengeReqDTO {
 
     @Schema(description = "검색 키워드 (챌린지 제목 검색)", example = "플로깅")
     private String keyword;
-
-    @Schema(description = "정렬 타입 (모집 중인 챌린지 검색 시 사용)",
-        example = "DEADLINE_SOON",
-        allowableValues = {"DEADLINE_SOON", "NEWEST"})
-    private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
 
     @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
     @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchOpenChallengeReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/SearchOpenChallengeReqDTO.java
@@ -1,0 +1,31 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
+
+@Schema(description = "모집 중인 챌린지 검색 요청 DTO")
+@Getter
+@Setter
+public class SearchOpenChallengeReqDTO {
+
+    @Schema(description = "검색 키워드 (챌린지 제목 검색)", example = "플로깅")
+    private String keyword;
+
+    @Schema(description = "정렬 타입",
+        example = "DEADLINE_SOON",
+        allowableValues = {"DEADLINE_SOON", "NEWEST"})
+    private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
+
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer page = 0;
+
+    @Schema(description = "페이지 크기", example = "10", minimum = "1", maximum = "100")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
+    private Integer size = 10;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -4,8 +4,32 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 
 public interface ChallengeRepositoryCustom {
 
     Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable);
+
+    /**
+     * 모집 마감 챌린지 검색
+     * - 시작일이 오늘 이전인 챌린지를 검색
+     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
+     *
+     * @param keyword  검색 키워드 (챌린지 제목)
+     * @param pageable 페이징 정보
+     * @return 검색 결과
+     */
+    Page<Challenge> searchClosedChallenges(String keyword, Pageable pageable);
+
+    /**
+     * 모집 중인 챌린지 검색
+     * - 시작일이 오늘 이후인 챌린지를 검색
+     * - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
+     *
+     * @param keyword  검색 키워드 (챌린지 제목)
+     * @param sortType 정렬 타입
+     * @param pageable 페이징 정보
+     * @return 검색 결과
+     */
+    Page<Challenge> searchOpenChallenges(String keyword, SearchSortType sortType, Pageable pageable);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
+import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
 @RequiredArgsConstructor
@@ -123,5 +125,87 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
             .where(builder)
             .fetchOne();
         return count != null ? count : 0L;
+    }
+
+    /**
+     * 모집 마감 챌린지 검색
+     * - 시작일이 오늘 이전인 챌린지를 검색
+     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
+     */
+    @Override
+    public Page<Challenge> searchClosedChallenges(String keyword, Pageable pageable) {
+        QChallenge challenge = QChallenge.challenge;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 모집 마감 조건: 시작일이 오늘 이전
+        builder.and(challenge.startDate.lt(LocalDate.now()));
+
+        // 제목 키워드 필터
+        addTitleKeywordFilter(builder, challenge, keyword);
+
+        // 쿼리 실행 - 오늘 날짜에 가까운 순 (startDate 내림차순)
+        List<Challenge> content = queryFactory
+            .selectFrom(challenge)
+            .where(builder)
+            .orderBy(challenge.startDate.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = countTotal(challenge, builder);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 모집 중인 챌린지 검색
+     * - 시작일이 오늘 이후인 챌린지를 검색
+     * - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
+     */
+    @Override
+    public Page<Challenge> searchOpenChallenges(String keyword, SearchSortType sortType,
+        Pageable pageable) {
+        QChallenge challenge = QChallenge.challenge;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 모집 중 조건: 시작일이 오늘 이후 (오늘 포함)
+        builder.and(challenge.startDate.goe(LocalDate.now()));
+
+        // 제목 키워드 필터
+        addTitleKeywordFilter(builder, challenge, keyword);
+
+        // 쿼리 생성
+        JPAQuery<Challenge> query = queryFactory
+            .selectFrom(challenge)
+            .where(builder);
+
+        // 정렬 적용
+        if (sortType == SearchSortType.NEWEST) {
+            // 최신순: 생성일 내림차순
+            query.orderBy(challenge.createdAt.desc());
+        } else {
+            // 마감 임박순 (기본값): 시작일 오름차순
+            query.orderBy(challenge.startDate.asc());
+        }
+
+        List<Challenge> content = query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = countTotal(challenge, builder);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 제목 키워드 필터 추가 (제목만 검색)
+     */
+    private void addTitleKeywordFilter(BooleanBuilder builder, QChallenge challenge,
+        String keyword) {
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            String likeKeyword = "%" + keyword.trim() + "%";
+            builder.and(challenge.title.likeIgnoreCase(likeKeyword));
+        }
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -56,8 +56,7 @@ public interface ChallengeService {
     JoinChallengeResDTO joinChallenge(Long challengeId, Long memberId);
 
     /**
-     * 모집이 마감된 챌린지를 제목으로 검색합니다.
-     * 시작일이 오늘 이전인 챌린지를 대상으로 하며, 오늘 날짜에 가까운 순으로 정렬됩니다.
+     * 모집이 마감된 챌린지를 제목으로 검색합니다. 시작일이 오늘 이전인 챌린지를 대상으로 하며, 오늘 날짜에 가까운 순으로 정렬됩니다.
      *
      * @param requestDTO 검색 조건 (키워드, 페이징 정보)
      * @return 페이지네이션된 검색 결과
@@ -66,13 +65,14 @@ public interface ChallengeService {
         SearchClosedChallengeReqDTO requestDTO);
 
     /**
-     * 모집 중인 챌린지를 제목으로 검색합니다.
-     * 시작일이 오늘 이후인 챌린지를 대상으로 하며, 마감 임박순 또는 최신순으로 정렬할 수 있습니다.
+     * 모집 중인 챌린지를 제목으로 검색합니다. 시작일이 오늘 이후인 챌린지를 대상으로 하며, 마감 임박순 또는 최신순으로 정렬할 수 있습니다.
      *
      * @param requestDTO 검색 조건 (키워드, 정렬 타입, 페이징 정보)
      * @return 페이지네이션된 검색 결과
      */
     PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(SearchOpenChallengeReqDTO requestDTO);
+
+    /**
      * 챌린지를 찜합니다.
      *
      * @param challengeId 찜할 챌린지 ID

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
@@ -52,4 +53,22 @@ public interface ChallengeService {
      * @return 챌린지 참여 결과
      */
     JoinChallengeResDTO joinChallenge(Long challengeId, Long memberId);
+
+    /**
+     * 모집이 마감된 챌린지를 제목으로 검색합니다.
+     * 시작일이 오늘 이전인 챌린지를 대상으로 하며, 오늘 날짜에 가까운 순으로 정렬됩니다.
+     *
+     * @param requestDTO 검색 조건 (키워드, 페이징 정보)
+     * @return 페이지네이션된 검색 결과
+     */
+    PageResponseDTO<ChallengeListResDTO> searchClosedChallenges(SearchChallengeReqDTO requestDTO);
+
+    /**
+     * 모집 중인 챌린지를 제목으로 검색합니다.
+     * 시작일이 오늘 이후인 챌린지를 대상으로 하며, 마감 임박순 또는 최신순으로 정렬할 수 있습니다.
+     *
+     * @param requestDTO 검색 조건 (키워드, 정렬 타입, 페이징 정보)
+     * @return 페이지네이션된 검색 결과
+     */
+    PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(SearchChallengeReqDTO requestDTO);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -4,7 +4,8 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
@@ -61,7 +62,8 @@ public interface ChallengeService {
      * @param requestDTO 검색 조건 (키워드, 페이징 정보)
      * @return 페이지네이션된 검색 결과
      */
-    PageResponseDTO<ChallengeListResDTO> searchClosedChallenges(SearchChallengeReqDTO requestDTO);
+    PageResponseDTO<ChallengeListResDTO> searchClosedChallenges(
+        SearchClosedChallengeReqDTO requestDTO);
 
     /**
      * 모집 중인 챌린지를 제목으로 검색합니다.
@@ -70,5 +72,5 @@ public interface ChallengeService {
      * @param requestDTO 검색 조건 (키워드, 정렬 타입, 페이징 정보)
      * @return 페이지네이션된 검색 결과
      */
-    PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(SearchChallengeReqDTO requestDTO);
+    PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(SearchOpenChallengeReqDTO requestDTO);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
@@ -320,5 +321,63 @@ public class ChallengeServiceImpl implements ChallengeService {
             .filter(pointLog -> pointLog.getStatus() == targetStatus)
             .mapToInt(PointLog::getPoints)
             .sum();
+    }
+
+    /**
+     * 모집 마감 챌린지 검색
+     * - 시작일이 오늘 이전인 챌린지를 대상으로 검색
+     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
+     */
+    @Override
+    public PageResponseDTO<ChallengeListResDTO> searchClosedChallenges(
+        SearchChallengeReqDTO requestDTO) {
+        Pageable pageable = PageRequest.of(
+            requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+            requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+
+        Page<Challenge> page = challengeRepository.searchClosedChallenges(
+            requestDTO.getKeyword(), pageable);
+
+        List<ChallengeListResDTO> content = page.getContent().stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
+
+        return PageResponseDTO.<ChallengeListResDTO>builder()
+            .content(content)
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .hasNext(page.hasNext())
+            .build();
+    }
+
+    /**
+     * 모집 중인 챌린지 검색
+     * - 시작일이 오늘 이후인 챌린지를 대상으로 검색
+     * - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
+     */
+    @Override
+    public PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(
+        SearchChallengeReqDTO requestDTO) {
+        Pageable pageable = PageRequest.of(
+            requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+            requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+
+        Page<Challenge> page = challengeRepository.searchOpenChallenges(
+            requestDTO.getKeyword(), requestDTO.getSortType(), pageable);
+
+        List<ChallengeListResDTO> content = page.getContent().stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
+
+        return PageResponseDTO.<ChallengeListResDTO>builder()
+            .content(content)
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .hasNext(page.hasNext())
+            .build();
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -226,7 +226,8 @@ public class ChallengeServiceImpl implements ChallengeService {
             challengeMemberOpt.isEmpty() && challenge.getStatus() != ChallengeStatus.END;
 
         // 찜 여부 확인
-        boolean isLiked = challengeLikeRepository.existsByMemberIdAndChallengeId(memberId, challengeId);
+        boolean isLiked = challengeLikeRepository.existsByMemberIdAndChallengeId(memberId,
+            challengeId);
 
         // 챌린지 상태
         ChallengeMemberStatus status = challengeMemberOpt
@@ -331,9 +332,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 모집 마감 챌린지 검색
-     * - 시작일이 오늘 이전인 챌린지를 대상으로 검색
-     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
+     * 모집 마감 챌린지 검색 - 시작일이 오늘 이전인 챌린지를 대상으로 검색 - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> searchClosedChallenges(
@@ -360,9 +359,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 모집 중인 챌린지 검색
-     * - 시작일이 오늘 이후인 챌린지를 대상으로 검색
-     * - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
+     * 모집 중인 챌린지 검색 - 시작일이 오늘 이후인 챌린지를 대상으로 검색 - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(
@@ -386,6 +383,8 @@ public class ChallengeServiceImpl implements ChallengeService {
             .totalPages(page.getTotalPages())
             .hasNext(page.hasNext())
             .build();
+    }
+
     @Override
     public void likeChallenge(Long challengeId, Long memberId) {
         // 챌린지 존재 확인
@@ -423,7 +422,8 @@ public class ChallengeServiceImpl implements ChallengeService {
             .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
 
         // 찜한 기록 조회
-        ChallengeLike challengeLike = challengeLikeRepository.findByMemberIdAndChallengeId(memberId, challengeId)
+        ChallengeLike challengeLike = challengeLikeRepository.findByMemberIdAndChallengeId(memberId,
+                challengeId)
             .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_LIKED_CHALLENGE));
 
         // ChallengeLike 엔티티 삭제

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -15,7 +15,8 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
-import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeListResDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeResDTO;
@@ -330,7 +331,7 @@ public class ChallengeServiceImpl implements ChallengeService {
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> searchClosedChallenges(
-        SearchChallengeReqDTO requestDTO) {
+        SearchClosedChallengeReqDTO requestDTO) {
         Pageable pageable = PageRequest.of(
             requestDTO.getPage() != null ? requestDTO.getPage() : 0,
             requestDTO.getSize() != null ? requestDTO.getSize() : 10);
@@ -359,7 +360,7 @@ public class ChallengeServiceImpl implements ChallengeService {
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> searchOpenChallenges(
-        SearchChallengeReqDTO requestDTO) {
+        SearchOpenChallengeReqDTO requestDTO) {
         Pageable pageable = PageRequest.of(
             requestDTO.getPage() != null ? requestDTO.getPage() : 0,
             requestDTO.getSize() != null ? requestDTO.getSize() : 10);

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/SearchSortType.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/SearchSortType.java
@@ -1,0 +1,11 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+/**
+ * 챌린지 검색 결과 정렬 타입
+ * - DEADLINE_SOON: 마감 임박순 (시작일 오름차순)
+ * - NEWEST: 최신순 (생성일 내림차순)
+ */
+public enum SearchSortType {
+    DEADLINE_SOON,  // 마감 임박순: startDate 오름차순
+    NEWEST          // 최신순: createdAt 내림차순
+}


### PR DESCRIPTION
## 📌 이슈 번호
- closed #85

## 🍬 기능 설명
- 챌린지 제목을 기준으로 검색하는 기능 추가
- 모집 상태에 따라 별도의 API로 분리하여 제공
- 각 API에 맞는 전용 DTO 사용 (불필요한 필드 제거)

### API 엔드포인트
| Method | Endpoint | DTO | 설명 |
|--------|----------|-----|------|
| GET | `/challenge/search/closed` | SearchClosedChallengeReqDTO | 모집 마감 챌린지 검색 |
| GET | `/challenge/search/open` | SearchOpenChallengeReqDTO | 모집 중인 챌린지 검색 |

### 요청 파라미터

#### 1. 모집 마감 챌린지 검색 (`/challenge/search/closed`)
| 파라미터 | 타입 | 필수 | 설명 |
|----------|------|------|------|
| keyword | String | X | 검색 키워드 (챌린지 제목) |
| page | Integer | X | 페이지 번호 (기본값: 0, 최소: 0) |
| size | Integer | X | 페이지 크기 (기본값: 10, 최소: 1, 최대: 100) |

#### 2. 모집 중인 챌린지 검색 (`/challenge/search/open`)
| 파라미터 | 타입 | 필수 | 설명 |
|----------|------|------|------|
| keyword | String | X | 검색 키워드 (챌린지 제목) |
| sortType | SearchSortType | X | 정렬 타입 (DEADLINE_SOON / NEWEST, 기본값: DEADLINE_SOON) |
| page | Integer | X | 페이지 번호 (기본값: 0, 최소: 0) |
| size | Integer | X | 페이지 크기 (기본값: 10, 최소: 1, 최대: 100) |

### 정렬 방식
- **모집 마감 챌린지**: 오늘 날짜에 가까운 순 (startDate 내림차순, 고정)
- **모집 중인 챌린지**:
  - `DEADLINE_SOON`: 마감 임박순 (startDate 오름차순)
  - `NEWEST`: 최신순 (createdAt 내림차순)

## 🤔 코드 리뷰에서 집중적으로 볼 내용

### 1. DTO 분리
모집 마감 챌린지 검색에는 sortType이 필요 없으므로 DTO를 분리했습니다.

```java
// 모집 마감: sortType 없음 (고정 정렬)
public class SearchClosedChallengeReqDTO {
    private String keyword;
    private Integer page = 0;
    private Integer size = 10;
}

// 모집 중: sortType 포함 (선택 가능한 정렬)
public class SearchOpenChallengeReqDTO {
    private String keyword;
    private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
    private Integer page = 0;
    private Integer size = 10;
}
```

**이점:**
- API별로 명확한 인터페이스 제공
- 사용하지 않는 필드로 인한 혼란 방지
- 각 API의 의도가 코드에서 명확히 드러남

### 2. 모집 마감 기준
시작일(startDate)을 기준으로 모집 마감 여부를 판단했습니다.
- `startDate < today`: 모집 마감
- `startDate >= today`: 모집 중

```java
// ChallengeRepositoryImpl.java
// 모집 마감 조건: 시작일이 오늘 이전
builder.and(challenge.startDate.lt(LocalDate.now()));

// 모집 중 조건: 시작일이 오늘 이후 (오늘 포함)
builder.and(challenge.startDate.goe(LocalDate.now()));
```

### 3. 검색 범위
기존 `addKeywordFilter`는 제목+설명을 검색하지만, 새 검색 API는 제목만 검색합니다.

```java
// 기존: 제목 + 설명 검색
challenge.title.likeIgnoreCase(keyword)
    .or(challenge.details.likeIgnoreCase(keyword))

// 신규: 제목만 검색
challenge.title.likeIgnoreCase(likeKeyword)
```

## ⭐ 기타 사항

### 변경된 파일
| 구분 | 파일 |
|------|------|
| 신규 | `global/enums/SearchSortType.java` |
| 신규 | `domain/challenge/dto/req/SearchClosedChallengeReqDTO.java` |
| 신규 | `domain/challenge/dto/req/SearchOpenChallengeReqDTO.java` |
| 수정 | `domain/challenge/controller/ChallengeController.java` |
| 수정 | `domain/challenge/service/ChallengeService.java` |
| 수정 | `domain/challenge/service/ChallengeServiceImpl.java` |
| 수정 | `domain/challenge/repository/ChallengeRepositoryCustom.java` |
| 수정 | `domain/challenge/repository/ChallengeRepositoryImpl.java` |

### QueryDSL 사용 이유
- 기존 코드베이스 패턴 준수
- 동적 쿼리 구성의 용이성 (키워드 유무에 따른 조건 추가)
- 타입 안전성 및 컴파일 타임 오류 검출