### PR TITLE
[Feat] 피드 검색 기능 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedCreateReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedSearchReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedCreateResDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedLikeResDTO;
@@ -134,5 +135,19 @@ public class FeedController {
         @Parameter(description = "페이지 크기", example = "10") @Min(1) @Max(10) @RequestParam(defaultValue = "4") int size) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(feedService.getMyFeedList(memberId, category, page, size));
+    }
+
+    @Operation(summary = "피드 검색", description = "피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "피드 검색 성공",
+            content = @Content(schema = @Schema(implementation = SliceResponseDTO.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/search")
+    public BaseResponse<SliceResponseDTO<PreviewFeedResDTO>> searchFeeds(
+        Authentication authentication,
+        @Parameter(description = "피드 검색 필터 조건") @Valid @ModelAttribute FeedSearchReqDTO requestDTO) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(feedService.searchFeeds(memberId, requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/req/FeedSearchReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/req/FeedSearchReqDTO.java
@@ -1,0 +1,35 @@
+package site.beilsang.beilsang_server_v2.domain.feed.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.FeedSortType;
+
+/**
+ * 피드 검색 요청 DTO
+ * 피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.
+ */
+@Schema(description = "피드 검색 요청 DTO")
+@Getter
+@Setter
+public class FeedSearchReqDTO {
+
+    @Schema(description = "검색 키워드 (피드 내용 검색)", example = "오늘의 플로깅")
+    private String keyword;
+
+    @Schema(description = "정렬 타입",
+        example = "NEWEST",
+        allowableValues = {"NEWEST", "OLDEST"})
+    private FeedSortType sortType = FeedSortType.NEWEST;
+
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer page = 0;
+
+    @Schema(description = "페이지 크기", example = "4", minimum = "1", maximum = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    @Max(value = 10, message = "페이지 크기는 10 이하여야 합니다")
+    private Integer size = 4;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 
-public interface FeedRepository extends JpaRepository<Feed, Long> {
+public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
 
     Long countByChallengeMember_IdIn(List<Long> challengeMemberIds);
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepositoryCustom.java
@@ -1,0 +1,19 @@
+package site.beilsang.beilsang_server_v2.domain.feed.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
+import site.beilsang.beilsang_server_v2.global.enums.FeedSortType;
+
+public interface FeedRepositoryCustom {
+
+    /**
+     * 피드 검색 피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.
+     *
+     * @param keyword  검색 키워드 (review 필드 검색, null인 경우 전체 조회)
+     * @param sortType 정렬 타입 (NEWEST: 최신순, OLDEST: 오래된순)
+     * @param pageable 페이징 정보
+     * @return 검색된 피드 목록 (Slice)
+     */
+    Slice<Feed> searchFeeds(String keyword, FeedSortType sortType, Pageable pageable);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepositoryImpl.java
@@ -1,0 +1,98 @@
+package site.beilsang.beilsang_server_v2.domain.feed.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
+import site.beilsang.beilsang_server_v2.domain.feed.entity.QFeed;
+import site.beilsang.beilsang_server_v2.global.enums.FeedSortType;
+
+/**
+ * Feed Repository의 Custom 구현체
+ * QueryDSL을 사용한 복잡한 쿼리를 구현합니다.
+ */
+@RequiredArgsConstructor
+public class FeedRepositoryImpl implements FeedRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 피드 검색
+     * 피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.
+     *
+     * @param keyword  검색 키워드 (review 필드 검색, null인 경우 전체 조회)
+     * @param sortType 정렬 타입 (NEWEST: 최신순, OLDEST: 오래된순)
+     * @param pageable 페이징 정보
+     * @return 검색된 피드 목록 (Slice)
+     */
+    @Override
+    public Slice<Feed> searchFeeds(String keyword, FeedSortType sortType, Pageable pageable) {
+        QFeed feed = QFeed.feed;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 키워드 필터링 (review 필드 검색)
+        addKeywordFilter(builder, feed, keyword);
+
+        // 쿼리 생성
+        JPAQuery<Feed> query = queryFactory
+            .selectFrom(feed)
+            .where(builder);
+
+        // 정렬 적용
+        applySorting(query, feed, sortType);
+
+        // limit + 1 방식으로 hasNext 판단
+        List<Feed> content = query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1)  // 하나 더 조회
+            .fetch();
+
+        // hasNext 계산
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            hasNext = true;
+            content.remove(pageable.getPageSize());  // 마지막 요소 제거
+        }
+
+        // Slice 생성 및 반환
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    /**
+     * 키워드 필터 추가
+     * review 필드에 대해 대소문자 구분 없이 검색합니다.
+     *
+     * @param builder BooleanBuilder
+     * @param feed    QFeed
+     * @param keyword 검색 키워드
+     */
+    private void addKeywordFilter(BooleanBuilder builder, QFeed feed, String keyword) {
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            String likeKeyword = "%" + keyword.trim() + "%";
+            builder.and(feed.review.likeIgnoreCase(likeKeyword));
+        }
+    }
+
+    /**
+     * 정렬 적용
+     * sortType에 따라 createdAt 기준으로 정렬합니다.
+     *
+     * @param query    JPAQuery
+     * @param feed     QFeed
+     * @param sortType 정렬 타입
+     */
+    private void applySorting(JPAQuery<Feed> query, QFeed feed, FeedSortType sortType) {
+        if (sortType == FeedSortType.OLDEST) {
+            // 오래된순: createdAt 오름차순
+            query.orderBy(feed.createdAt.asc());
+        } else {
+            // 최신순 (기본값): createdAt 내림차순
+            query.orderBy(feed.createdAt.desc());
+        }
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.feed.service;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedCreateReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedSearchReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedCreateResDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedLikeResDTO;
@@ -73,4 +74,13 @@ public interface FeedService {
      */
     SliceResponseDTO<PreviewFeedResDTO> getMyFeedList(Long memberId, Category category, int page,
         int size);
+
+    /**
+     * 피드를 검색합니다. 피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.
+     *
+     * @param memberId   요청한 사용자 ID (좋아요 상태 확인용)
+     * @param requestDTO 피드 검색 요청 DTO (keyword, sortType, page, size)
+     * @return 슬라이스된 피드 검색 결과 (무한 스크롤용)
+     */
+    SliceResponseDTO<PreviewFeedResDTO> searchFeeds(Long memberId, FeedSearchReqDTO requestDTO);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.FeedAssembler;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedCreateReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedSearchReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedCreateResDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedDetailResDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.res.FeedLikeResDTO;
@@ -190,6 +191,27 @@ public class FeedServiceImpl implements FeedService {
             feedSlice = feedRepository.findAllByChallengeMember_Member_IdAndChallenge_CategoryOrderByCreatedAtDesc(
                 memberId, category, pageable);
         }
+
+        // SliceResponseDTO로 변환하여 반환
+        return FeedAssembler.toSliceResponseDTO(feedSlice);
+    }
+
+    @Override
+    public SliceResponseDTO<PreviewFeedResDTO> searchFeeds(Long memberId,
+        FeedSearchReqDTO requestDTO) {
+        // 사용자 존재 여부 확인
+        memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + memberId));
+
+        // Pageable 객체 생성 (정렬은 Repository에서 sortType에 따라 처리)
+        Pageable pageable = PageRequest.of(requestDTO.getPage(), requestDTO.getSize());
+
+        // Repository의 searchFeeds 호출
+        Slice<Feed> feedSlice = feedRepository.searchFeeds(
+            requestDTO.getKeyword(),
+            requestDTO.getSortType(),
+            pageable
+        );
 
         // SliceResponseDTO로 변환하여 반환
         return FeedAssembler.toSliceResponseDTO(feedSlice);

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/FeedSortType.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/FeedSortType.java
@@ -1,0 +1,11 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+/**
+ * 피드 검색 결과 정렬 타입
+ * - NEWEST: 최신순 (생성일 내림차순)
+ * - OLDEST: 오래된순 (생성일 오름차순)
+ */
+public enum FeedSortType {
+    NEWEST,  // 최신순: createdAt 내림차순
+    OLDEST   // 오래된순: createdAt 오름차순
+}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
closed #90 

## 🍬 기능 설명

피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬하는 기능을 구현함.

### 주요 기능
- **검색 기능**: 피드 내용(review)을 대소문자 구분 없이 검색
- **정렬 기능**: 등록 시간(createdAt) 기준 오름차순/내림차순 정렬 지원
  - `NEWEST`: 최신순 (createdAt 내림차순)
  - `OLDEST`: 오래된순 (createdAt 오름차순)
- **무한 스크롤**: Slice 타입 반환으로 무한 스크롤 지원

### API 명세
- **엔드포인트**: `GET /feed/search`
- **요청 파라미터**:
  - `keyword` (optional): 검색 키워드
  - `sortType` (optional, default: NEWEST): 정렬 타입
  - `page` (optional, default: 0): 페이지 번호
  - `size` (optional, default: 4, max: 10): 페이지 크기
- **응답**: `SliceResponseDTO<PreviewFeedResDTO>`

### 구현 내역

#### 1. 기본 타입 및 DTO
- `FeedSortType` enum: 정렬 타입 정의
- `FeedSearchReqDTO`: 검색 요청 DTO

#### 2. Repository 레이어
- `FeedRepositoryCustom`: Custom Repository 인터페이스
- `FeedRepositoryImpl`: QueryDSL 기반 검색 쿼리 구현
  - review 필드 대소문자 구분 없는 검색 (`likeIgnoreCase`)
  - sortType에 따른 동적 정렬
  - **limit + 1 방식**으로 hasNext 판단

#### 3. Service 레이어
- `FeedService`: searchFeeds 메서드 추가
- `FeedServiceImpl`: 비즈니스 로직 구현

#### 4. Controller 레이어
- `FeedController`: `GET /feed/search` 엔드포인트 추가
- Swagger 문서화 완료

## 🤔 코드 리뷰에서 집중적으로 볼 내용

### 1. QueryDSL 구현 패턴
```java
// FeedRepositoryImpl.java
public Slice<Feed> searchFeeds(String keyword, FeedSortType sortType, Pageable pageable) {
    QFeed feed = QFeed.feed;
    BooleanBuilder builder = new BooleanBuilder();

    // 키워드 필터링
    addKeywordFilter(builder, feed, keyword);

    // 쿼리 생성 및 정렬
    JPAQuery<Feed> query = queryFactory
        .selectFrom(feed)
        .where(builder);
    applySorting(query, feed, sortType);

    // limit + 1 방식으로 hasNext 판단
    List<Feed> content = query
        .offset(pageable.getOffset())
        .limit(pageable.getPageSize() + 1)
        .fetch();

    boolean hasNext = false;
    if (content.size() > pageable.getPageSize()) {
        hasNext = true;
        content.remove(pageable.getPageSize());
    }

    return new SliceImpl<>(content, pageable, hasNext);
}
```

**포인트**:
- 기존 `ChallengeRepositoryImpl`의 패턴을 따름
- `likeIgnoreCase`를 사용한 대소문자 구분 없는 검색
- limit + 1 방식으로 다음 페이지 존재 여부 효율적으로 판단

### 2. 정렬 로직
```java
private void applySorting(JPAQuery<Feed> query, QFeed feed, FeedSortType sortType) {
    if (sortType == FeedSortType.OLDEST) {
        query.orderBy(feed.createdAt.asc());
    } else {
        query.orderBy(feed.createdAt.desc());
    }
}
```

**포인트**:
- sortType에 따른 동적 정렬 처리
- 기본값은 NEWEST (최신순)

## ⭐ 기타 사항

### 참고한 파일
- `ChallengeRepositoryImpl.java`: QueryDSL 검색 구현 패턴 참고
- `SearchOpenChallengeReqDTO.java`: DTO 작성 패턴 참고
- `FeedServiceImpl.getFeedList()`: 기존 피드 조회 로직 참고

### 추후 개선 사항
- review 필드에 인덱스 추가 검토 (검색 성능 최적화)
- 통합 테스트 작성
  - Repository 테스트: 키워드 검색, 정렬, 페이징, hasNext 검증
  - Service 테스트: DTO 변환 로직 검증
  - Controller 테스트: API 호출 및 응답 검증