### PR TITLE
[Refac] 챌린지 조회 API 개선 - 용도별 전용 API 분리

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -59,7 +60,12 @@ public class ChallengeController {
                 certImages));
     }
 
-    @Operation(summary = "챌린지 목록 조회", description = "조건에 따른 챌린지 목록을 페이지네이션으로 조회합니다.")
+    @Deprecated
+    @Operation(summary = "챌린지 목록 조회 (Deprecated)",
+        description = "조건에 따른 챌린지 목록을 페이지네이션으로 조회합니다. "
+            + "이 API는 더 이상 권장되지 않습니다. 용도별 전용 API를 사용해주세요: "
+            + "/challenge/list/open, /challenge/list/closed, /challenge/liked, /challenge/my",
+        deprecated = true)
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "챌린지 목록 조회 성공"),
         @ApiResponse(responseCode = "401", description = "인증 실패")
@@ -71,6 +77,18 @@ public class ChallengeController {
         Long memberId = (Long) authentication.getPrincipal();
         requestDTO.setMemberId(memberId);
         return new BaseResponse<>(challengeService.getChallengeList(requestDTO));
+    }
+
+    @Operation(summary = "모집중 챌린지 목록 조회",
+        description = "현재 모집중인 챌린지 목록을 조회합니다. 시작일이 오늘 이후인 챌린지를 대상으로 합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "모집중 챌린지 목록 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/list/open")
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getOpenChallengeList(
+        @Parameter(description = "모집중 챌린지 목록 조회 조건") @ModelAttribute OpenChallengeListReqDTO requestDTO) {
+        return new BaseResponse<>(challengeService.getOpenChallengeList(requestDTO));
     }
 
     @Operation(summary = "챌린지 상세 조회", description = "특정 챌린지의 상세 정보를 조회합니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -23,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
@@ -102,6 +103,20 @@ public class ChallengeController {
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getClosedChallengeList(
         @Parameter(description = "모집마감 챌린지 목록 조회 조건") @ModelAttribute ClosedChallengeListReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.getClosedChallengeList(requestDTO));
+    }
+
+    @Operation(summary = "찜한 챌린지 목록 조회",
+        description = "내가 찜한 챌린지 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "찜한 챌린지 목록 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/liked")
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getLikedChallengeList(
+        Authentication authentication,
+        @Parameter(description = "찜한 챌린지 목록 조회 조건") @ModelAttribute LikedChallengeListReqDTO requestDTO) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(challengeService.getLikedChallengeList(memberId, requestDTO));
     }
 
     @Operation(summary = "챌린지 상세 조회", description = "특정 챌린지의 상세 정보를 조회합니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -24,6 +24,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRe
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
@@ -117,6 +118,21 @@ public class ChallengeController {
         @Parameter(description = "찜한 챌린지 목록 조회 조건") @ModelAttribute LikedChallengeListReqDTO requestDTO) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.getLikedChallengeList(memberId, requestDTO));
+    }
+
+    @Operation(summary = "나의 챌린지 목록 조회",
+        description = "내가 참여한 챌린지 목록을 상태별로 조회합니다. "
+            + "ONGOING(참여중), SUCCESS(달성), FAIL(실패) 상태로 필터링합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "나의 챌린지 목록 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/my")
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getMyChallengeList(
+        Authentication authentication,
+        @Parameter(description = "나의 챌린지 목록 조회 조건") @ModelAttribute MyChallengeListReqDTO requestDTO) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(challengeService.getMyChallengeList(memberId, requestDTO));
     }
 
     @Operation(summary = "챌린지 상세 조회", description = "특정 챌린지의 상세 정보를 조회합니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -91,7 +92,7 @@ public class ChallengeController {
     })
     @GetMapping("/list/open")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getOpenChallengeList(
-        @Parameter(description = "모집중 챌린지 목록 조회 조건") @ModelAttribute OpenChallengeListReqDTO requestDTO) {
+        @Parameter(description = "모집중 챌린지 목록 조회 조건") @Valid @ModelAttribute OpenChallengeListReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.getOpenChallengeList(requestDTO));
     }
 
@@ -103,7 +104,7 @@ public class ChallengeController {
     })
     @GetMapping("/list/closed")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getClosedChallengeList(
-        @Parameter(description = "모집마감 챌린지 목록 조회 조건") @ModelAttribute ClosedChallengeListReqDTO requestDTO) {
+        @Parameter(description = "모집마감 챌린지 목록 조회 조건") @Valid @ModelAttribute ClosedChallengeListReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.getClosedChallengeList(requestDTO));
     }
 
@@ -116,7 +117,7 @@ public class ChallengeController {
     @GetMapping("/liked")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getLikedChallengeList(
         Authentication authentication,
-        @Parameter(description = "찜한 챌린지 목록 조회 조건") @ModelAttribute LikedChallengeListReqDTO requestDTO) {
+        @Parameter(description = "찜한 챌린지 목록 조회 조건") @Valid @ModelAttribute LikedChallengeListReqDTO requestDTO) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.getLikedChallengeList(memberId, requestDTO));
     }
@@ -131,7 +132,7 @@ public class ChallengeController {
     @GetMapping("/my")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getMyChallengeList(
         Authentication authentication,
-        @Parameter(description = "나의 챌린지 목록 조회 조건") @ModelAttribute MyChallengeListReqDTO requestDTO) {
+        @Parameter(description = "나의 챌린지 목록 조회 조건") @Valid @ModelAttribute MyChallengeListReqDTO requestDTO) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.getMyChallengeList(memberId, requestDTO));
     }
@@ -144,7 +145,7 @@ public class ChallengeController {
     })
     @GetMapping("/recommended")
     public BaseResponse<List<ChallengeListResDTO>> getRecommendedChallenges(
-        @Parameter(description = "추천 챌린지 조회 조건") @ModelAttribute RecommendedChallengeReqDTO requestDTO) {
+        @Parameter(description = "추천 챌린지 조회 조건") @Valid @ModelAttribute RecommendedChallengeReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.getRecommendedChallenges(requestDTO));
     }
 
@@ -217,7 +218,7 @@ public class ChallengeController {
     })
     @GetMapping("/search/closed")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> searchClosedChallenges(
-        @Parameter(description = "모집 마감 챌린지 검색 조건") @ModelAttribute SearchClosedChallengeReqDTO requestDTO) {
+        @Parameter(description = "모집 마감 챌린지 검색 조건") @Valid @ModelAttribute SearchClosedChallengeReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.searchClosedChallenges(requestDTO));
     }
 
@@ -229,7 +230,7 @@ public class ChallengeController {
     })
     @GetMapping("/search/open")
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> searchOpenChallenges(
-        @Parameter(description = "모집 중인 챌린지 검색 조건") @ModelAttribute SearchOpenChallengeReqDTO requestDTO) {
+        @Parameter(description = "모집 중인 챌린지 검색 조건") @Valid @ModelAttribute SearchOpenChallengeReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.searchOpenChallenges(requestDTO));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
@@ -89,6 +90,18 @@ public class ChallengeController {
     public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getOpenChallengeList(
         @Parameter(description = "모집중 챌린지 목록 조회 조건") @ModelAttribute OpenChallengeListReqDTO requestDTO) {
         return new BaseResponse<>(challengeService.getOpenChallengeList(requestDTO));
+    }
+
+    @Operation(summary = "모집마감 챌린지 목록 조회",
+        description = "모집이 마감된 챌린지 목록을 조회합니다. 시작일이 오늘 이전인 챌린지를 대상으로 합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "모집마감 챌린지 목록 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/list/closed")
+    public BaseResponse<PageResponseDTO<ChallengeListResDTO>> getClosedChallengeList(
+        @Parameter(description = "모집마감 챌린지 목록 조회 조건") @ModelAttribute ClosedChallengeListReqDTO requestDTO) {
+        return new BaseResponse<>(challengeService.getClosedChallengeList(requestDTO));
     }
 
     @Operation(summary = "챌린지 상세 조회", description = "특정 챌린지의 상세 정보를 조회합니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/controller/ChallengeController.java
@@ -26,6 +26,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallenge
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.RecommendedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -133,6 +134,18 @@ public class ChallengeController {
         @Parameter(description = "나의 챌린지 목록 조회 조건") @ModelAttribute MyChallengeListReqDTO requestDTO) {
         Long memberId = (Long) authentication.getPrincipal();
         return new BaseResponse<>(challengeService.getMyChallengeList(memberId, requestDTO));
+    }
+
+    @Operation(summary = "추천 챌린지 조회",
+        description = "현재 모집 중인 챌린지 중 좋아요가 많은 순으로 추천 챌린지를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "추천 챌린지 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/recommended")
+    public BaseResponse<List<ChallengeListResDTO>> getRecommendedChallenges(
+        @Parameter(description = "추천 챌린지 조회 조건") @ModelAttribute RecommendedChallengeReqDTO requestDTO) {
+        return new BaseResponse<>(challengeService.getRecommendedChallenges(requestDTO));
     }
 
     @Operation(summary = "챌린지 상세 조회", description = "특정 챌린지의 상세 정보를 조회합니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ClosedChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ClosedChallengeListReqDTO.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
@@ -21,6 +22,7 @@ public class ClosedChallengeListReqDTO {
         example = "ALL",
         allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
             "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    @NotNull(message = "카테고리는 필수입니다")
     private Category category = Category.ALL;
 
     @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ClosedChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/ClosedChallengeListReqDTO.java
@@ -1,0 +1,34 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+
+/**
+ * 모집마감 챌린지 목록 조회 요청 DTO
+ * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
+ * - 정렬은 최근 마감순(startDate DESC)으로 고정
+ */
+@Schema(description = "모집마감 챌린지 목록 조회 요청 DTO")
+@Getter
+@Setter
+public class ClosedChallengeListReqDTO {
+
+    @Schema(description = "카테고리 필터 (null이면 전체 조회)",
+        example = "TUMBLER",
+        allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
+            "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    private Category category;
+
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer page = 0;
+
+    @Schema(description = "페이지 크기", example = "10", minimum = "1", maximum = "100")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
+    private Integer size = 10;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/LikedChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/LikedChallengeListReqDTO.java
@@ -6,22 +6,28 @@ import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 
 /**
- * 모집마감 챌린지 목록 조회 요청 DTO
- * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
- * - 정렬은 최근 마감순(startDate DESC)으로 고정
+ * 찜한 챌린지 목록 조회 요청 DTO
+ * - 내가 찜한 챌린지 목록을 조회
+ * - 카테고리 필터링 및 정렬 기능 제공
  */
-@Schema(description = "모집마감 챌린지 목록 조회 요청 DTO")
+@Schema(description = "찜한 챌린지 목록 조회 요청 DTO")
 @Getter
 @Setter
-public class ClosedChallengeListReqDTO {
+public class LikedChallengeListReqDTO {
 
     @Schema(description = "카테고리 필터 (ALL: 전체 조회)",
         example = "ALL",
         allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
             "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
     private Category category = Category.ALL;
+
+    @Schema(description = "정렬 타입: DEADLINE_SOON(마감 임박순), NEWEST(최신순)",
+        example = "DEADLINE_SOON",
+        allowableValues = {"DEADLINE_SOON", "NEWEST"})
+    private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
 
     @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
     @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/LikedChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/LikedChallengeListReqDTO.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
@@ -22,6 +23,7 @@ public class LikedChallengeListReqDTO {
         example = "ALL",
         allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
             "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    @NotNull(message = "카테고리는 필수입니다")
     private Category category = Category.ALL;
 
     @Schema(description = "정렬 타입: DEADLINE_SOON(마감 임박순), NEWEST(최신순)",

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/MyChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/MyChallengeListReqDTO.java
@@ -30,6 +30,7 @@ public class MyChallengeListReqDTO {
         example = "ALL",
         allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
             "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    @NotNull(message = "카테고리는 필수입니다")
     private Category category = Category.ALL;
 
     @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/MyChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/MyChallengeListReqDTO.java
@@ -1,0 +1,43 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ParticipationStatus;
+
+/**
+ * 나의 챌린지 목록 조회 요청 DTO
+ * - 내가 참여한 챌린지 목록을 상태별로 조회
+ * - 정렬은 참여일(createdAt) 내림차순으로 고정
+ */
+@Schema(description = "나의 챌린지 목록 조회 요청 DTO")
+@Getter
+@Setter
+public class MyChallengeListReqDTO {
+
+    @Schema(description = "참여 상태 (필수): ONGOING(참여중), SUCCESS(달성), FAIL(실패)",
+        example = "ONGOING",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+        allowableValues = {"ONGOING", "SUCCESS", "FAIL"})
+    @NotNull(message = "참여 상태는 필수입니다")
+    private ParticipationStatus participationStatus;
+
+    @Schema(description = "카테고리 필터 (ALL: 전체 조회)",
+        example = "ALL",
+        allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
+            "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    private Category category = Category.ALL;
+
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer page = 0;
+
+    @Schema(description = "페이지 크기", example = "10", minimum = "1", maximum = "100")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
+    private Integer size = 10;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/OpenChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/OpenChallengeListReqDTO.java
@@ -18,11 +18,11 @@ import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 @Setter
 public class OpenChallengeListReqDTO {
 
-    @Schema(description = "카테고리 필터 (null이면 전체 조회)",
-        example = "TUMBLER",
+    @Schema(description = "카테고리 필터 (ALL: 전체 조회)",
+        example = "ALL",
         allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
             "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
-    private Category category;
+    private Category category = Category.ALL;
 
     @Schema(description = "정렬 타입: DEADLINE_SOON(마감 임박순), NEWEST(최신순)",
         example = "DEADLINE_SOON",

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/OpenChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/OpenChallengeListReqDTO.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
@@ -22,6 +23,7 @@ public class OpenChallengeListReqDTO {
         example = "ALL",
         allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
             "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    @NotNull(message = "카테고리는 필수입니다")
     private Category category = Category.ALL;
 
     @Schema(description = "정렬 타입: DEADLINE_SOON(마감 임박순), NEWEST(최신순)",

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/OpenChallengeListReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/OpenChallengeListReqDTO.java
@@ -1,0 +1,40 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
+
+/**
+ * 모집중 챌린지 목록 조회 요청 DTO
+ * - 시작일이 오늘 이후인 챌린지를 대상으로 조회
+ * - 카테고리 필터링 및 정렬 기능 제공
+ */
+@Schema(description = "모집중 챌린지 목록 조회 요청 DTO")
+@Getter
+@Setter
+public class OpenChallengeListReqDTO {
+
+    @Schema(description = "카테고리 필터 (null이면 전체 조회)",
+        example = "TUMBLER",
+        allowableValues = {"ALL", "TUMBLER", "REFILL_STATION", "MULTIPLE_CONTAINERS",
+            "ECO_PRODUCT", "PLOGGING", "VEGAN", "PUBLIC_TRANSPORT", "BIKE", "RECYCLE"})
+    private Category category;
+
+    @Schema(description = "정렬 타입: DEADLINE_SOON(마감 임박순), NEWEST(최신순)",
+        example = "DEADLINE_SOON",
+        allowableValues = {"DEADLINE_SOON", "NEWEST"})
+    private SearchSortType sortType = SearchSortType.DEADLINE_SOON;
+
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer page = 0;
+
+    @Schema(description = "페이지 크기", example = "10", minimum = "1", maximum = "100")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
+    private Integer size = 10;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/RecommendedChallengeReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/req/RecommendedChallengeReqDTO.java
@@ -1,0 +1,23 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 추천 챌린지 조회 요청 DTO
+ * - 현재 모집 중인 챌린지 중 좋아요 순으로 조회
+ * - 페이지네이션 없이 상위 N개만 조회
+ */
+@Schema(description = "추천 챌린지 조회 요청 DTO")
+@Getter
+@Setter
+public class RecommendedChallengeReqDTO {
+
+    @Schema(description = "조회할 챌린지 개수", example = "10", minimum = "1", maximum = "50")
+    @Min(value = 1, message = "조회 개수는 1 이상이어야 합니다")
+    @Max(value = 50, message = "조회 개수는 50 이하여야 합니다")
+    private Integer size = 10;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
@@ -33,6 +34,19 @@ public interface ChallengeRepositoryCustom {
      * @return 모집마감된 챌린지 목록
      */
     Page<Challenge> findClosedChallenges(ClosedChallengeListReqDTO requestDTO, Pageable pageable);
+
+    /**
+     * 찜한 챌린지 목록 조회
+     * - 특정 회원이 찜한 챌린지 목록을 조회
+     * - 카테고리 필터링 및 정렬 기능 제공
+     *
+     * @param memberId   회원 ID
+     * @param requestDTO 조회 조건 (카테고리, 정렬 타입)
+     * @param pageable   페이징 정보
+     * @return 찜한 챌린지 목록
+     */
+    Page<Challenge> findLikedChallenges(Long memberId, LikedChallengeListReqDTO requestDTO,
+        Pageable pageable);
 
     /**
      * 모집 마감 챌린지 검색

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
@@ -46,6 +47,21 @@ public interface ChallengeRepositoryCustom {
      * @return 찜한 챌린지 목록
      */
     Page<Challenge> findLikedChallenges(Long memberId, LikedChallengeListReqDTO requestDTO,
+        Pageable pageable);
+
+    /**
+     * 나의 챌린지 목록 조회
+     * - 특정 회원이 참여한 챌린지 목록을 상태별로 조회
+     * - ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
+     * - SUCCESS: ChallengeMemberStatus = SUCCESS
+     * - FAIL: ChallengeMemberStatus = FAIL
+     *
+     * @param memberId   회원 ID
+     * @param requestDTO 조회 조건 (참여상태, 카테고리)
+     * @param pageable   페이징 정보
+     * @return 나의 챌린지 목록
+     */
+    Page<Challenge> findMyChallenges(Long memberId, MyChallengeListReqDTO requestDTO,
         Pageable pageable);
 
     /**

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
@@ -21,6 +22,17 @@ public interface ChallengeRepositoryCustom {
      * @return 모집중인 챌린지 목록
      */
     Page<Challenge> findOpenChallenges(OpenChallengeListReqDTO requestDTO, Pageable pageable);
+
+    /**
+     * 모집마감된 챌린지 목록 조회
+     * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
+     * - 최근 마감순(startDate DESC)으로 정렬
+     *
+     * @param requestDTO 조회 조건 (카테고리)
+     * @param pageable   페이징 정보
+     * @return 모집마감된 챌린지 목록
+     */
+    Page<Challenge> findClosedChallenges(ClosedChallengeListReqDTO requestDTO, Pageable pageable);
 
     /**
      * 모집 마감 챌린지 검색

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -65,6 +65,16 @@ public interface ChallengeRepositoryCustom {
         Pageable pageable);
 
     /**
+     * 추천 챌린지 조회
+     * - 현재 모집 중인 챌린지(startDate >= today) 중 좋아요가 많은 순으로 조회
+     * - 페이지네이션 없이 상위 N개만 조회
+     *
+     * @param size 조회할 챌린지 개수
+     * @return 추천 챌린지 목록
+     */
+    List<Challenge> findRecommendedChallenges(int size);
+
+    /**
      * 모집 마감 챌린지 검색
      * - 시작일이 오늘 이전인 챌린지를 검색
      * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -3,12 +3,24 @@ package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 
 public interface ChallengeRepositoryCustom {
 
     Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable);
+
+    /**
+     * 모집중인 챌린지 목록 조회
+     * - 시작일이 오늘 이후인 챌린지를 대상으로 조회
+     * - 카테고리 필터링 및 정렬 기능 제공
+     *
+     * @param requestDTO 조회 조건 (카테고리, 정렬 타입)
+     * @param pageable   페이징 정보
+     * @return 모집중인 챌린지 목록
+     */
+    Page<Challenge> findOpenChallenges(OpenChallengeListReqDTO requestDTO, Pageable pageable);
 
     /**
      * 모집 마감 챌린지 검색

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.challenge.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
@@ -15,9 +16,7 @@ public interface ChallengeRepositoryCustom {
     Page<Challenge> findChallenges(ChallengeListReqDTO requestDTO, Pageable pageable);
 
     /**
-     * 모집중인 챌린지 목록 조회
-     * - 시작일이 오늘 이후인 챌린지를 대상으로 조회
-     * - 카테고리 필터링 및 정렬 기능 제공
+     * 모집중인 챌린지 목록 조회 - 시작일이 오늘 이후인 챌린지를 대상으로 조회 - 카테고리 필터링 및 정렬 기능 제공
      *
      * @param requestDTO 조회 조건 (카테고리, 정렬 타입)
      * @param pageable   페이징 정보
@@ -26,9 +25,7 @@ public interface ChallengeRepositoryCustom {
     Page<Challenge> findOpenChallenges(OpenChallengeListReqDTO requestDTO, Pageable pageable);
 
     /**
-     * 모집마감된 챌린지 목록 조회
-     * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
-     * - 최근 마감순(startDate DESC)으로 정렬
+     * 모집마감된 챌린지 목록 조회 - 시작일이 오늘 이전인 챌린지를 대상으로 조회 - 최근 마감순(startDate DESC)으로 정렬
      *
      * @param requestDTO 조회 조건 (카테고리)
      * @param pageable   페이징 정보
@@ -37,9 +34,7 @@ public interface ChallengeRepositoryCustom {
     Page<Challenge> findClosedChallenges(ClosedChallengeListReqDTO requestDTO, Pageable pageable);
 
     /**
-     * 찜한 챌린지 목록 조회
-     * - 특정 회원이 찜한 챌린지 목록을 조회
-     * - 카테고리 필터링 및 정렬 기능 제공
+     * 찜한 챌린지 목록 조회 - 특정 회원이 찜한 챌린지 목록을 조회 - 카테고리 필터링 및 정렬 기능 제공
      *
      * @param memberId   회원 ID
      * @param requestDTO 조회 조건 (카테고리, 정렬 타입)
@@ -50,11 +45,8 @@ public interface ChallengeRepositoryCustom {
         Pageable pageable);
 
     /**
-     * 나의 챌린지 목록 조회
-     * - 특정 회원이 참여한 챌린지 목록을 상태별로 조회
-     * - ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
-     * - SUCCESS: ChallengeMemberStatus = SUCCESS
-     * - FAIL: ChallengeMemberStatus = FAIL
+     * 나의 챌린지 목록 조회 - 특정 회원이 참여한 챌린지 목록을 상태별로 조회 - ONGOING: ChallengeMemberStatus = ONGOING 또는
+     * NOT_YET - SUCCESS: ChallengeMemberStatus = SUCCESS - FAIL: ChallengeMemberStatus = FAIL
      *
      * @param memberId   회원 ID
      * @param requestDTO 조회 조건 (참여상태, 카테고리)
@@ -65,9 +57,7 @@ public interface ChallengeRepositoryCustom {
         Pageable pageable);
 
     /**
-     * 추천 챌린지 조회
-     * - 현재 모집 중인 챌린지(startDate >= today) 중 좋아요가 많은 순으로 조회
-     * - 페이지네이션 없이 상위 N개만 조회
+     * 추천 챌린지 조회 - 현재 모집 중인 챌린지(startDate >= today) 중 좋아요가 많은 순으로 조회 - 페이지네이션 없이 상위 N개만 조회
      *
      * @param size 조회할 챌린지 개수
      * @return 추천 챌린지 목록
@@ -75,9 +65,7 @@ public interface ChallengeRepositoryCustom {
     List<Challenge> findRecommendedChallenges(int size);
 
     /**
-     * 모집 마감 챌린지 검색
-     * - 시작일이 오늘 이전인 챌린지를 검색
-     * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
+     * 모집 마감 챌린지 검색 - 시작일이 오늘 이전인 챌린지를 검색 - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)
      *
      * @param keyword  검색 키워드 (챌린지 제목)
      * @param pageable 페이징 정보
@@ -86,14 +74,13 @@ public interface ChallengeRepositoryCustom {
     Page<Challenge> searchClosedChallenges(String keyword, Pageable pageable);
 
     /**
-     * 모집 중인 챌린지 검색
-     * - 시작일이 오늘 이후인 챌린지를 검색
-     * - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
+     * 모집 중인 챌린지 검색 - 시작일이 오늘 이후인 챌린지를 검색 - 정렬: 마감 임박순(DEADLINE_SOON) 또는 최신순(NEWEST)
      *
      * @param keyword  검색 키워드 (챌린지 제목)
      * @param sortType 정렬 타입
      * @param pageable 페이징 정보
      * @return 검색 결과
      */
-    Page<Challenge> searchOpenChallenges(String keyword, SearchSortType sortType, Pageable pageable);
+    Page<Challenge> searchOpenChallenges(String keyword, SearchSortType sortType,
+        Pageable pageable);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -11,8 +11,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
@@ -125,6 +127,49 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
             .where(builder)
             .fetchOne();
         return count != null ? count : 0L;
+    }
+
+    /**
+     * 모집중인 챌린지 목록 조회
+     * - 시작일이 오늘 이후인 챌린지를 대상으로 조회
+     * - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
+     */
+    @Override
+    public Page<Challenge> findOpenChallenges(OpenChallengeListReqDTO requestDTO,
+        Pageable pageable) {
+        QChallenge challenge = QChallenge.challenge;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 모집중 조건: 시작일이 오늘 이후 (오늘 포함)
+        builder.and(challenge.startDate.goe(LocalDate.now()));
+
+        // 카테고리 필터 (ALL이 아니고 null이 아닌 경우에만 필터링)
+        if (requestDTO.getCategory() != null && requestDTO.getCategory() != Category.ALL) {
+            builder.and(challenge.category.eq(requestDTO.getCategory()));
+        }
+
+        // 쿼리 생성
+        JPAQuery<Challenge> query = queryFactory
+            .selectFrom(challenge)
+            .where(builder);
+
+        // 정렬 적용
+        if (requestDTO.getSortType() == SearchSortType.NEWEST) {
+            // 최신순: 생성일 내림차순
+            query.orderBy(challenge.createdAt.desc());
+        } else {
+            // 마감 임박순 (기본값): 시작일 오름차순
+            query.orderBy(challenge.startDate.asc());
+        }
+
+        List<Challenge> content = query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = countTotal(challenge, builder);
+
+        return new PageImpl<>(content, pageable, total);
     }
 
     /**

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
@@ -163,6 +164,39 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         }
 
         List<Challenge> content = query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = countTotal(challenge, builder);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 모집마감된 챌린지 목록 조회
+     * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
+     * - 최근 마감순(startDate DESC)으로 정렬
+     */
+    @Override
+    public Page<Challenge> findClosedChallenges(ClosedChallengeListReqDTO requestDTO,
+        Pageable pageable) {
+        QChallenge challenge = QChallenge.challenge;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 모집마감 조건: 시작일이 오늘 이전
+        builder.and(challenge.startDate.lt(LocalDate.now()));
+
+        // 카테고리 필터 (ALL이 아니고 null이 아닌 경우에만 필터링)
+        if (requestDTO.getCategory() != null && requestDTO.getCategory() != Category.ALL) {
+            builder.and(challenge.category.eq(requestDTO.getCategory()));
+        }
+
+        // 쿼리 실행 - 최근 마감순 (startDate 내림차순)
+        List<Challenge> content = queryFactory
+            .selectFrom(challenge)
+            .where(builder)
+            .orderBy(challenge.startDate.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -13,11 +13,15 @@ import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
 import site.beilsang.beilsang_server_v2.domain.like.entity.QChallengeLike;
+import site.beilsang.beilsang_server_v2.domain.member.entity.QChallengeMember;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ParticipationStatus;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
 
@@ -251,6 +255,64 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
             .from(challenge)
             .innerJoin(challengeLike).on(challengeLike.challenge.eq(challenge))
             .where(challengeLike.member.id.eq(memberId).and(builder))
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    /**
+     * 나의 챌린지 목록 조회
+     * - 내가 참여한 챌린지를 상태별로 조회
+     * - ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
+     * - SUCCESS: ChallengeMemberStatus = SUCCESS
+     * - FAIL: ChallengeMemberStatus = FAIL
+     * - 정렬은 참여일(createdAt) 내림차순으로 고정
+     */
+    @Override
+    public Page<Challenge> findMyChallenges(Long memberId, MyChallengeListReqDTO requestDTO,
+        Pageable pageable) {
+        QChallenge challenge = QChallenge.challenge;
+        QChallengeMember challengeMember = QChallengeMember.challengeMember;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 카테고리 필터 (ALL이 아닌 경우에만 필터링)
+        if (requestDTO.getCategory() != Category.ALL) {
+            builder.and(challenge.category.eq(requestDTO.getCategory()));
+        }
+
+        // 참여 상태 필터
+        BooleanBuilder statusBuilder = new BooleanBuilder();
+        ParticipationStatus status = requestDTO.getParticipationStatus();
+        if (status == ParticipationStatus.ONGOING) {
+            // ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
+            statusBuilder.and(challengeMember.challengeMemberStatus.in(
+                ChallengeMemberStatus.ONGOING, ChallengeMemberStatus.NOT_YET));
+        } else if (status == ParticipationStatus.SUCCESS) {
+            statusBuilder.and(challengeMember.challengeMemberStatus.eq(ChallengeMemberStatus.SUCCESS));
+        } else if (status == ParticipationStatus.FAIL) {
+            statusBuilder.and(challengeMember.challengeMemberStatus.eq(ChallengeMemberStatus.FAIL));
+        }
+
+        // 쿼리 생성 - ChallengeMember 조인
+        List<Challenge> content = queryFactory
+            .selectFrom(challenge)
+            .innerJoin(challengeMember).on(challengeMember.challenge.eq(challenge))
+            .where(challengeMember.member.id.eq(memberId)
+                .and(statusBuilder)
+                .and(builder))
+            .orderBy(challengeMember.createdAt.desc())  // 참여일 내림차순
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        // 전체 개수 조회
+        Long total = queryFactory
+            .select(challenge.count())
+            .from(challenge)
+            .innerJoin(challengeMember).on(challengeMember.challenge.eq(challenge))
+            .where(challengeMember.member.id.eq(memberId)
+                .and(statusBuilder)
+                .and(builder))
             .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -319,6 +319,23 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
     }
 
     /**
+     * 추천 챌린지 조회
+     * - 현재 모집 중인 챌린지(startDate >= today) 중 좋아요가 많은 순으로 조회
+     * - 페이지네이션 없이 상위 N개만 조회
+     */
+    @Override
+    public List<Challenge> findRecommendedChallenges(int size) {
+        QChallenge challenge = QChallenge.challenge;
+
+        return queryFactory
+            .selectFrom(challenge)
+            .where(challenge.startDate.goe(LocalDate.now()))  // 모집 중 조건
+            .orderBy(challenge.countLikes.desc(), challenge.startDate.asc())  // 좋아요 내림차순, 시작일 오름차순
+            .limit(size)
+            .fetch();
+    }
+
+    /**
      * 모집 마감 챌린지 검색
      * - 시작일이 오늘 이전인 챌린지를 검색
      * - 오늘 날짜에 가까운 순으로 정렬 (startDate 내림차순)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -12,9 +12,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.QChallenge;
+import site.beilsang.beilsang_server_v2.domain.like.entity.QChallengeLike;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.SearchSortType;
 import site.beilsang.beilsang_server_v2.global.enums.SortDirection;
@@ -144,8 +146,8 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         // 모집중 조건: 시작일이 오늘 이후 (오늘 포함)
         builder.and(challenge.startDate.goe(LocalDate.now()));
 
-        // 카테고리 필터 (ALL이 아니고 null이 아닌 경우에만 필터링)
-        if (requestDTO.getCategory() != null && requestDTO.getCategory() != Category.ALL) {
+        // 카테고리 필터 (ALL이 아닌 경우에만 필터링)
+        if (requestDTO.getCategory() != Category.ALL) {
             builder.and(challenge.category.eq(requestDTO.getCategory()));
         }
 
@@ -187,8 +189,8 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         // 모집마감 조건: 시작일이 오늘 이전
         builder.and(challenge.startDate.lt(LocalDate.now()));
 
-        // 카테고리 필터 (ALL이 아니고 null이 아닌 경우에만 필터링)
-        if (requestDTO.getCategory() != null && requestDTO.getCategory() != Category.ALL) {
+        // 카테고리 필터 (ALL이 아닌 경우에만 필터링)
+        if (requestDTO.getCategory() != Category.ALL) {
             builder.and(challenge.category.eq(requestDTO.getCategory()));
         }
 
@@ -204,6 +206,54 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         long total = countTotal(challenge, builder);
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 찜한 챌린지 목록 조회
+     * - 특정 회원이 찜한 챌린지 목록을 조회
+     * - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
+     */
+    @Override
+    public Page<Challenge> findLikedChallenges(Long memberId, LikedChallengeListReqDTO requestDTO,
+        Pageable pageable) {
+        QChallenge challenge = QChallenge.challenge;
+        QChallengeLike challengeLike = QChallengeLike.challengeLike;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 카테고리 필터 (ALL이 아닌 경우에만 필터링)
+        if (requestDTO.getCategory() != Category.ALL) {
+            builder.and(challenge.category.eq(requestDTO.getCategory()));
+        }
+
+        // 쿼리 생성 - ChallengeLike 조인
+        JPAQuery<Challenge> query = queryFactory
+            .selectFrom(challenge)
+            .innerJoin(challengeLike).on(challengeLike.challenge.eq(challenge))
+            .where(challengeLike.member.id.eq(memberId).and(builder));
+
+        // 정렬 적용
+        if (requestDTO.getSortType() == SearchSortType.NEWEST) {
+            // 최신순: 시작일 내림차순
+            query.orderBy(challenge.startDate.desc());
+        } else {
+            // 마감 임박순 (기본값): 시작일 오름차순
+            query.orderBy(challenge.startDate.asc());
+        }
+
+        List<Challenge> content = query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        // 전체 개수 조회
+        Long total = queryFactory
+            .select(challenge.count())
+            .from(challenge)
+            .innerJoin(challengeLike).on(challengeLike.challenge.eq(challenge))
+            .where(challengeLike.member.id.eq(memberId).and(builder))
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     /**

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -6,6 +6,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRe
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
@@ -70,6 +71,17 @@ public interface ChallengeService {
      */
     PageResponseDTO<ChallengeListResDTO> getLikedChallengeList(Long memberId,
         LikedChallengeListReqDTO requestDTO);
+
+    /**
+     * 나의 챌린지 목록을 조회합니다.
+     * 참여 상태(ONGOING, SUCCESS, FAIL)별로 필터링하여 조회합니다.
+     *
+     * @param memberId   조회 요청하는 회원 ID
+     * @param requestDTO 나의 챌린지 목록 조회 조건 (참여상태, 카테고리, 페이징)
+     * @return 페이지네이션된 나의 챌린지 목록
+     */
+    PageResponseDTO<ChallengeListResDTO> getMyChallengeList(Long memberId,
+        MyChallengeListReqDTO requestDTO);
 
     /**
      * 특정 챌린지의 상세 정보를 조회합니다.

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -34,8 +35,20 @@ public interface ChallengeService {
      *
      * @param requestDTO 챌린지 목록 조회 필터 조건
      * @return 페이지네이션된 챌린지 목록
+     * @deprecated 용도별 전용 API를 사용해주세요:
+     *     {@link #getOpenChallengeList}, {@link #getClosedChallengeList},
+     *     {@link #getLikedChallengeList}, {@link #getMyChallengeList}
      */
+    @Deprecated
     PageResponseDTO<ChallengeListResDTO> getChallengeList(ChallengeListReqDTO requestDTO);
+
+    /**
+     * 모집중인 챌린지 목록을 조회합니다. 시작일이 오늘 이후인 챌린지를 대상으로 합니다.
+     *
+     * @param requestDTO 모집중 챌린지 목록 조회 조건 (카테고리, 정렬, 페이징)
+     * @return 페이지네이션된 모집중 챌린지 목록
+     */
+    PageResponseDTO<ChallengeListResDTO> getOpenChallengeList(OpenChallengeListReqDTO requestDTO);
 
     /**
      * 특정 챌린지의 상세 정보를 조회합니다.

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.challenge.service;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
@@ -49,6 +50,15 @@ public interface ChallengeService {
      * @return 페이지네이션된 모집중 챌린지 목록
      */
     PageResponseDTO<ChallengeListResDTO> getOpenChallengeList(OpenChallengeListReqDTO requestDTO);
+
+    /**
+     * 모집마감된 챌린지 목록을 조회합니다. 시작일이 오늘 이전인 챌린지를 대상으로 합니다.
+     * 최근 마감순(startDate DESC)으로 정렬됩니다.
+     *
+     * @param requestDTO 모집마감 챌린지 목록 조회 조건 (카테고리, 페이징)
+     * @return 페이지네이션된 모집마감 챌린지 목록
+     */
+    PageResponseDTO<ChallengeListResDTO> getClosedChallengeList(ClosedChallengeListReqDTO requestDTO);
 
     /**
      * 특정 챌린지의 상세 정보를 조회합니다.

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -8,6 +8,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallenge
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.RecommendedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -82,6 +83,15 @@ public interface ChallengeService {
      */
     PageResponseDTO<ChallengeListResDTO> getMyChallengeList(Long memberId,
         MyChallengeListReqDTO requestDTO);
+
+    /**
+     * 추천 챌린지를 조회합니다.
+     * 현재 모집 중인 챌린지 중 좋아요가 많은 순으로 조회합니다.
+     *
+     * @param requestDTO 추천 챌린지 조회 조건 (조회 개수)
+     * @return 추천 챌린지 목록
+     */
+    List<ChallengeListResDTO> getRecommendedChallenges(RecommendedChallengeReqDTO requestDTO);
 
     /**
      * 특정 챌린지의 상세 정보를 조회합니다.

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeService.java
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
@@ -59,6 +60,16 @@ public interface ChallengeService {
      * @return 페이지네이션된 모집마감 챌린지 목록
      */
     PageResponseDTO<ChallengeListResDTO> getClosedChallengeList(ClosedChallengeListReqDTO requestDTO);
+
+    /**
+     * 찜한 챌린지 목록을 조회합니다.
+     *
+     * @param memberId   조회 요청하는 회원 ID
+     * @param requestDTO 찜한 챌린지 목록 조회 조건 (카테고리, 정렬, 페이징)
+     * @return 페이지네이션된 찜한 챌린지 목록
+     */
+    PageResponseDTO<ChallengeListResDTO> getLikedChallengeList(Long memberId,
+        LikedChallengeListReqDTO requestDTO);
 
     /**
      * 특정 챌린지의 상세 정보를 조회합니다.

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -19,6 +19,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallenge
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.RecommendedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -330,6 +331,22 @@ public class ChallengeServiceImpl implements ChallengeService {
             .totalPages(page.getTotalPages())
             .hasNext(page.hasNext())
             .build();
+    }
+
+    /**
+     * 추천 챌린지를 조회합니다.
+     * - 현재 모집 중인 챌린지 중 좋아요가 많은 순으로 조회
+     * - 페이지네이션 없이 상위 N개만 조회
+     */
+    @Override
+    public List<ChallengeListResDTO> getRecommendedChallenges(RecommendedChallengeReqDTO requestDTO) {
+        int size = requestDTO.getSize() != null ? requestDTO.getSize() : 10;
+
+        List<Challenge> challenges = challengeRepository.findRecommendedChallenges(size);
+
+        return challenges.stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
@@ -226,6 +227,34 @@ public class ChallengeServiceImpl implements ChallengeService {
             requestDTO.getSize() != null ? requestDTO.getSize() : 10);
 
         Page<Challenge> page = challengeRepository.findOpenChallenges(requestDTO, pageable);
+
+        List<ChallengeListResDTO> content = page.getContent().stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
+
+        return PageResponseDTO.<ChallengeListResDTO>builder()
+            .content(content)
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .hasNext(page.hasNext())
+            .build();
+    }
+
+    /**
+     * 모집마감된 챌린지 목록을 조회합니다.
+     * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
+     * - 최근 마감순(startDate DESC)으로 정렬
+     */
+    @Override
+    public PageResponseDTO<ChallengeListResDTO> getClosedChallengeList(
+        ClosedChallengeListReqDTO requestDTO) {
+        Pageable pageable = PageRequest.of(
+            requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+            requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+
+        Page<Challenge> page = challengeRepository.findClosedChallenges(requestDTO, pageable);
 
         List<ChallengeListResDTO> content = page.getContent().stream()
             .map(ChallengeAssembler::toChallengeListResDTO)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.res.ChallengeDetailResDTO;
@@ -192,6 +193,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         }
     }
 
+    @Deprecated
     @Override
     public PageResponseDTO<ChallengeListResDTO> getChallengeList(ChallengeListReqDTO requestDTO) {
         Pageable pageable = PageRequest.of(
@@ -201,6 +203,34 @@ public class ChallengeServiceImpl implements ChallengeService {
         List<ChallengeListResDTO> content = page.getContent().stream()
             .map(ChallengeAssembler::toChallengeListResDTO)
             .collect(Collectors.toList());
+        return PageResponseDTO.<ChallengeListResDTO>builder()
+            .content(content)
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .hasNext(page.hasNext())
+            .build();
+    }
+
+    /**
+     * 모집중인 챌린지 목록을 조회합니다.
+     * - 시작일이 오늘 이후인 챌린지를 대상으로 조회
+     * - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
+     */
+    @Override
+    public PageResponseDTO<ChallengeListResDTO> getOpenChallengeList(
+        OpenChallengeListReqDTO requestDTO) {
+        Pageable pageable = PageRequest.of(
+            requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+            requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+
+        Page<Challenge> page = challengeRepository.findOpenChallenges(requestDTO, pageable);
+
+        List<ChallengeListResDTO> content = page.getContent().stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
+
         return PageResponseDTO.<ChallengeListResDTO>builder()
             .content(content)
             .page(page.getNumber())

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -16,6 +16,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
@@ -255,6 +256,35 @@ public class ChallengeServiceImpl implements ChallengeService {
             requestDTO.getSize() != null ? requestDTO.getSize() : 10);
 
         Page<Challenge> page = challengeRepository.findClosedChallenges(requestDTO, pageable);
+
+        List<ChallengeListResDTO> content = page.getContent().stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
+
+        return PageResponseDTO.<ChallengeListResDTO>builder()
+            .content(content)
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .hasNext(page.hasNext())
+            .build();
+    }
+
+    /**
+     * 찜한 챌린지 목록을 조회합니다.
+     * - 내가 찜한 챌린지 목록을 조회
+     * - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
+     */
+    @Override
+    public PageResponseDTO<ChallengeListResDTO> getLikedChallengeList(Long memberId,
+        LikedChallengeListReqDTO requestDTO) {
+        Pageable pageable = PageRequest.of(
+            requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+            requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+
+        Page<Challenge> page = challengeRepository.findLikedChallenges(memberId, requestDTO,
+            pageable);
 
         List<ChallengeListResDTO> content = page.getContent().stream()
             .map(ChallengeAssembler::toChallengeListResDTO)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -17,6 +17,7 @@ import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListRe
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.CreateChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.LikedChallengeListReqDTO;
+import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.MyChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.OpenChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchClosedChallengeReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.SearchOpenChallengeReqDTO;
@@ -285,6 +286,37 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         Page<Challenge> page = challengeRepository.findLikedChallenges(memberId, requestDTO,
             pageable);
+
+        List<ChallengeListResDTO> content = page.getContent().stream()
+            .map(ChallengeAssembler::toChallengeListResDTO)
+            .collect(Collectors.toList());
+
+        return PageResponseDTO.<ChallengeListResDTO>builder()
+            .content(content)
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .hasNext(page.hasNext())
+            .build();
+    }
+
+    /**
+     * 나의 챌린지 목록을 조회합니다.
+     * - 내가 참여한 챌린지를 상태별로 조회
+     * - ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
+     * - SUCCESS: ChallengeMemberStatus = SUCCESS
+     * - FAIL: ChallengeMemberStatus = FAIL
+     * - 정렬은 참여일(createdAt) 내림차순으로 고정
+     */
+    @Override
+    public PageResponseDTO<ChallengeListResDTO> getMyChallengeList(Long memberId,
+        MyChallengeListReqDTO requestDTO) {
+        Pageable pageable = PageRequest.of(
+            requestDTO.getPage() != null ? requestDTO.getPage() : 0,
+            requestDTO.getSize() != null ? requestDTO.getSize() : 10);
+
+        Page<Challenge> page = challengeRepository.findMyChallenges(memberId, requestDTO, pageable);
 
         List<ChallengeListResDTO> content = page.getContent().stream()
             .map(ChallengeAssembler::toChallengeListResDTO)

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ParticipationStatus.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ParticipationStatus.java
@@ -1,0 +1,13 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+/**
+ * 나의 챌린지 참여 상태
+ * - ONGOING: 참여중 (ChallengeMemberStatus = ONGOING 또는 NOT_YET)
+ * - SUCCESS: 달성 (ChallengeMemberStatus = SUCCESS)
+ * - FAIL: 실패 (ChallengeMemberStatus = FAIL)
+ */
+public enum ParticipationStatus {
+    ONGOING,    // 참여중 (진행중 + 시작 전)
+    SUCCESS,    // 달성
+    FAIL        // 실패
+}


### PR DESCRIPTION
## 📌 이슈 번호
- closed #92 

## 🍬 기능 설명

기존의 복잡한 파라미터를 가진 슈퍼 API(`GET /challenge`)를 용도별 전용 API로 분리하여 사용성을 개선함.

### 신규 API

| API | 엔드포인트 | 설명 |
|-----|-----------|------|
| 모집중 챌린지 목록 | `GET /challenge/list/open` | 시작일이 오늘 이후인 챌린지 조회 |
| 모집마감 챌린지 목록 | `GET /challenge/list/closed` | 시작일이 오늘 이전인 챌린지 조회 |
| 찜한 챌린지 조회 | `GET /challenge/liked` | 내가 찜한 챌린지 조회 |
| 나의 챌린지 조회 | `GET /challenge/my` | 참여 상태별 챌린지 조회 |
| 추천 챌린지 | `GET /challenge/recommended` | 좋아요 순 추천 챌린지 조회 |

### 주요 변경사항

- 각 API별 전용 Request DTO 생성
- `ParticipationStatus` enum 추가 (ONGOING, SUCCESS, FAIL)
- 기존 `GET /challenge` API에 `@Deprecated` 처리
- 카테고리 파라미터 기본값을 `ALL`로 설정 (null 허용 안함)

### 파일 변경 내역

**신규 파일 (7개)**
- `ParticipationStatus.java` - 참여 상태 enum
- `OpenChallengeListReqDTO.java` - 모집중 챌린지 조회 DTO
- `ClosedChallengeListReqDTO.java` - 모집마감 챌린지 조회 DTO
- `LikedChallengeListReqDTO.java` - 찜한 챌린지 조회 DTO
- `MyChallengeListReqDTO.java` - 나의 챌린지 조회 DTO
- `RecommendedChallengeReqDTO.java` - 추천 챌린지 조회 DTO

**수정 파일 (5개)**
- `ChallengeController.java` - 5개 엔드포인트 추가
- `ChallengeService.java` - 5개 메서드 추가
- `ChallengeServiceImpl.java` - 5개 메서드 구현
- `ChallengeRepositoryCustom.java` - 5개 쿼리 메서드 추가
- `ChallengeRepositoryImpl.java` - 5개 QueryDSL 쿼리 구현

## 🤔 코드 리뷰에서 집중적으로 볼 내용

### 1. 나의 챌린지 참여 상태 필터링 로직

```java
// ChallengeRepositoryImpl.java
if (status == ParticipationStatus.ONGOING) {
    // ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
    statusBuilder.and(challengeMember.challengeMemberStatus.in(
        ChallengeMemberStatus.ONGOING, ChallengeMemberStatus.NOT_YET));
} else if (status == ParticipationStatus.SUCCESS) {
    statusBuilder.and(challengeMember.challengeMemberStatus.eq(ChallengeMemberStatus.SUCCESS));
} else if (status == ParticipationStatus.FAIL) {
    statusBuilder.and(challengeMember.challengeMemberStatus.eq(ChallengeMemberStatus.FAIL));
}
```

- `ParticipationStatus.ONGOING`이 `ChallengeMemberStatus.ONGOING`과 `NOT_YET` 두 가지를 포함하도록 설계함.

### 2. 찜한 챌린지 조회 쿼리

```java
// ChallengeRepositoryImpl.java - findLikedChallenges
JPAQuery<Challenge> query = queryFactory
    .selectFrom(challenge)
    .innerJoin(challengeLike).on(challengeLike.challenge.eq(challenge))
    .where(challengeLike.member.id.eq(memberId).and(builder));
```

- `ChallengeLike` 테이블과 INNER JOIN하여 찜한 챌린지만 조회됨.

### 3. 추천 챌린지 정렬 기준

```java
// ChallengeRepositoryImpl.java - findRecommendedChallenges
.orderBy(challenge.countLikes.desc(), challenge.startDate.asc())
```

- 좋아요 수가 같을 경우 시작일이 임박한 순으로 정렬함.

## ⭐ 기타 사항

### API 설계 원칙
- **단일 책임**: 각 API는 하나의 명확한 용도만 담당
- **최소 파라미터**: 해당 용도에 필요한 파라미터만 노출
- **합리적 기본값**: 파라미터 없이 호출해도 의미 있는 결과 반환
- **명확한 네이밍**: API 경로만으로 용도 파악 가능

### 마이그레이션
- 기존 `GET /challenge` API는 `@Deprecated` 처리
- 클라이언트는 용도에 맞는 새로운 API로 마이그레이션해야 함