### PR TITLE
[Feat] 챌린지 종료 시 포인트 정산 기능 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -87,8 +87,19 @@ public class Challenge extends BaseEntity {
 
     private Integer collectedPoint;
 
+    // 포인트 정산 완료 여부 (중복 정산 방지용)
+    @Builder.Default
+    private Boolean isSettled = false;
+
     public void updateStatus(ChallengeStatus status) {
         this.status = status;
+    }
+
+    /**
+     * 챌린지 포인트 정산 완료 처리
+     */
+    public void markAsSettled() {
+        this.isSettled = true;
     }
 
     public ChallengeStatus calculateCurrentStatus(LocalDate today) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeSettlementService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeSettlementService.java
@@ -1,0 +1,139 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
+import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMemberRepository;
+import site.beilsang.beilsang_server_v2.domain.point.service.PointService;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
+import site.beilsang.beilsang_server_v2.global.enums.PointName;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChallengeSettlementService {
+
+    private final ChallengeMemberRepository challengeMemberRepository;
+    private final PointService pointService;
+
+    // TODO: 호스트 보너스 정책 미확정 — 추후 논의 안건 상정 필요
+    private static final int HOST_BONUS_POINT = 0;
+
+    /**
+     * 챌린지 종료 시 포인트 정산을 수행합니다.
+     *
+     * 1. 중복 정산 확인
+     * 2. ONGOING 멤버들의 성공/실패 판정
+     * 3. 성공 멤버에게 collectedPoint 균등 분배
+     * 4. 호스트가 성공한 경우 보너스 포인트 지급
+     * 5. 정산 완료 표시
+     *
+     * @param challenge 정산 대상 챌린지 (상태가 END로 전환된 챌린지)
+     */
+    public void settleChallenge(Challenge challenge) {
+        // 1. 중복 정산 방지
+        if (Boolean.TRUE.equals(challenge.getIsSettled())) {
+            log.debug("챌린지 ID: {} — 이미 정산 완료된 챌린지입니다.", challenge.getId());
+            return;
+        }
+
+        // 2. ONGOING 상태인 멤버 목록 조회
+        List<ChallengeMember> ongoingMembers = challengeMemberRepository
+            .findAllByChallengeIdAndChallengeMemberStatus(
+                challenge.getId(), ChallengeMemberStatus.ONGOING);
+
+        if (ongoingMembers.isEmpty()) {
+            log.info("챌린지 ID: {} — ONGOING 멤버가 없어 정산을 건너뜁니다.", challenge.getId());
+            challenge.markAsSettled();
+            return;
+        }
+
+        // 3. 성공/실패 판정
+        List<ChallengeMember> successMembers = judgeMembers(challenge, ongoingMembers);
+
+        // 4. 포인트 정산
+        if (successMembers.isEmpty()) {
+            // 전원 실패 시 포인트 분배 없음 (collectedPoint 소멸)
+            log.info("챌린지 ID: {} — 전원 실패. collectedPoint {} 소멸",
+                challenge.getId(), challenge.getCollectedPoint());
+        } else {
+            distributePoints(challenge, successMembers);
+        }
+
+        // 5. 정산 완료 표시
+        challenge.markAsSettled();
+        log.info("챌린지 ID: {} — 정산 완료", challenge.getId());
+    }
+
+    /**
+     * ONGOING 멤버들의 성공/실패를 판정합니다.
+     * 판정 기준: successDays >= totalGoalDay → SUCCESS, 그 외 → FAIL
+     *
+     * @param challenge      정산 대상 챌린지
+     * @param ongoingMembers ONGOING 상태인 챌린지 멤버 목록
+     * @return 성공한 챌린지 멤버 목록
+     */
+    private List<ChallengeMember> judgeMembers(Challenge challenge,
+        List<ChallengeMember> ongoingMembers) {
+
+        List<ChallengeMember> successMembers = new ArrayList<>();
+
+        for (ChallengeMember member : ongoingMembers) {
+            if (member.getSuccessDays() >= challenge.getTotalGoalDay()) {
+                member.updateChallengeMemberStatus(ChallengeMemberStatus.SUCCESS);
+                successMembers.add(member);
+            } else {
+                member.updateChallengeMemberStatus(ChallengeMemberStatus.FAIL);
+            }
+        }
+
+        log.info("챌린지 ID: {} — 판정 완료 (전체: {}명, 성공: {}명, 실패: {}명)",
+            challenge.getId(), ongoingMembers.size(),
+            successMembers.size(), ongoingMembers.size() - successMembers.size());
+
+        return successMembers;
+    }
+
+    /**
+     * 성공 멤버들에게 포인트를 균등 분배합니다.
+     * 나머지 포인트(collectedPoint % 성공 멤버 수)는 소멸 처리합니다.
+     *
+     * @param challenge      정산 대상 챌린지
+     * @param successMembers 성공한 챌린지 멤버 목록
+     */
+    private void distributePoints(Challenge challenge, List<ChallengeMember> successMembers) {
+        int collectedPoint = challenge.getCollectedPoint();
+        int successCount = successMembers.size();
+
+        // 1인당 분배 포인트 (나머지는 소멸)
+        int pointPerMember = collectedPoint / successCount;
+        int remainderPoint = collectedPoint % successCount;
+
+        log.info("챌린지 ID: {} — 포인트 분배 (총: {}, 1인당: {}, 소멸: {})",
+            challenge.getId(), collectedPoint, pointPerMember, remainderPoint);
+
+        for (ChallengeMember challengeMember : successMembers) {
+            // 챌린지 성공 포인트 지급
+            pointService.grantChallengePoints(
+                challengeMember.getMember(), challenge, pointPerMember,
+                PointName.SUCCESS_CHALLENGE);
+
+            // 호스트인 경우 보너스 포인트 추가 지급
+            // TODO: 호스트 보너스 정책 미확정 — 추후 논의 안건 상정 필요
+            if (Boolean.TRUE.equals(challengeMember.getIsHost()) && HOST_BONUS_POINT > 0) {
+                pointService.grantChallengePoints(
+                    challengeMember.getMember(), challenge, HOST_BONUS_POINT,
+                    PointName.SUCCESS_CHALLENGE_HOST);
+
+                log.info("챌린지 ID: {} — 호스트(멤버 ID: {}) 보너스 포인트 {} 지급",
+                    challenge.getId(), challengeMember.getMember().getId(), HOST_BONUS_POINT);
+            }
+        }
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeStatusScheduler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeStatusScheduler.java
@@ -18,6 +18,7 @@ import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 public class ChallengeStatusScheduler {
 
     private final ChallengeRepository challengeRepository;
+    private final ChallengeSettlementService challengeSettlementService;
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
     public void updateChallengeStatuses() {
@@ -40,6 +41,11 @@ public class ChallengeStatusScheduler {
                 updatedCount++;
                 log.debug("챌린지 ID: {}, 상태 변경: {} -> {}",
                     challenge.getId(), currentStatus, calculatedStatus);
+
+                // END 상태로 전환된 챌린지에 대해 포인트 정산 수행
+                if (calculatedStatus == ChallengeStatus.END) {
+                    challengeSettlementService.settleChallenge(challenge);
+                }
             }
         }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/ChallengeMember.java
@@ -55,4 +55,11 @@ public class ChallengeMember extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "challengeMember", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Feed> feed = new ArrayList<>();
+
+    /**
+     * 챌린지 멤버 상태 변경 (정산 시 ONGOING → SUCCESS/FAIL 전환용)
+     */
+    public void updateChallengeMemberStatus(ChallengeMemberStatus status) {
+        this.challengeMemberStatus = status;
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -21,4 +21,8 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
 
     // 챌린지-멤버 단건 조회
     Optional<ChallengeMember> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
+
+    // 특정 챌린지의 특정 상태 멤버 목록 조회 (정산 시 ONGOING 멤버 조회용)
+    List<ChallengeMember> findAllByChallengeIdAndChallengeMemberStatus(
+        Long challengeId, ChallengeMemberStatus challengeMemberStatus);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/point/service/PointService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/point/service/PointService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.domain.point.entity.PointLog;
 import site.beilsang.beilsang_server_v2.domain.point.repository.PointLogRepository;
@@ -62,6 +63,33 @@ public class PointService {
             .points(points)
             .expirationDate(LocalDateTime.now().plusYears(1))       // 포인트 만료 기한 설정
             .member(member)
+            .build();
+
+        pointLogRepository.save(pointLog);
+
+        // 회원 포인트 잔액 업데이트
+        member.addPoint(points);
+    }
+
+    /**
+     * 챌린지 정산 포인트를 지급하고 포인트 로그를 생성합니다.
+     * 기존 grantPoints와 달리 PointLog에 챌린지 정보를 연결하여 정산 내역 추적이 가능합니다.
+     *
+     * @param member    포인트를 지급받을 회원
+     * @param challenge 정산 대상 챌린지
+     * @param points    지급할 포인트 금액
+     * @param pointName 포인트 지급 사유 (SUCCESS_CHALLENGE 또는 SUCCESS_CHALLENGE_HOST)
+     */
+    public void grantChallengePoints(Member member, Challenge challenge, int points,
+        PointName pointName) {
+        // 포인트 로그 생성 (챌린지 정보 포함)
+        PointLog pointLog = PointLog.builder()
+            .pointName(pointName)
+            .status(PointStatus.EARN)
+            .points(points)
+            .expirationDate(LocalDateTime.now().plusYears(1))
+            .member(member)
+            .challenge(challenge)
             .build();
 
         pointLogRepository.save(pointLog);

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeSettlementServiceTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeSettlementServiceTest.java
@@ -1,0 +1,211 @@
+package site.beilsang.beilsang_server_v2.domain.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMemberRepository;
+import site.beilsang.beilsang_server_v2.domain.point.service.PointService;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
+import site.beilsang.beilsang_server_v2.global.enums.PointName;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChallengeSettlementService 단위테스트")
+class ChallengeSettlementServiceTest {
+
+    @Mock
+    private ChallengeMemberRepository challengeMemberRepository;
+
+    @Mock
+    private PointService pointService;
+
+    @InjectMocks
+    private ChallengeSettlementService challengeSettlementService;
+
+    private Challenge challenge;
+    private Member member1;
+    private Member member2;
+    private Member member3;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 챌린지 (참가비 100, 목표 5일, 3명 참여 → collectedPoint 300)
+        challenge = Challenge.builder()
+            .id(1L)
+            .title("테스트 챌린지")
+            .totalGoalDay(5)
+            .joinPoint(100)
+            .collectedPoint(300)
+            .attendeeCount(3)
+            .isSettled(false)
+            .build();
+
+        member1 = Member.builder().id(1L).nickName("멤버1").point(0).build();
+        member2 = Member.builder().id(2L).nickName("멤버2").point(0).build();
+        member3 = Member.builder().id(3L).nickName("멤버3").point(0).build();
+    }
+
+    @Test
+    @DisplayName("전원 성공 — collectedPoint를 성공 멤버 수로 균등 분배")
+    void settleChallenge_AllSuccess() {
+        // given
+        List<ChallengeMember> ongoingMembers = List.of(
+            createChallengeMember(member1, false, 5),  // 목표 달성
+            createChallengeMember(member2, false, 7),  // 목표 초과 달성
+            createChallengeMember(member3, true, 5)    // 호스트, 목표 달성
+        );
+
+        when(challengeMemberRepository.findAllByChallengeIdAndChallengeMemberStatus(
+            1L, ChallengeMemberStatus.ONGOING)).thenReturn(ongoingMembers);
+
+        // when
+        challengeSettlementService.settleChallenge(challenge);
+
+        // then — 3명 전원 SUCCESS, 1인당 100포인트(300/3)
+        assertThat(ongoingMembers).allMatch(
+            m -> m.getChallengeMemberStatus() == ChallengeMemberStatus.SUCCESS);
+        verify(pointService, times(3)).grantChallengePoints(
+            any(Member.class), eq(challenge), eq(100), eq(PointName.SUCCESS_CHALLENGE));
+        assertThat(challenge.getIsSettled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("일부 성공 — 성공 멤버에게만 포인트 분배, 실패 멤버는 FAIL 상태")
+    void settleChallenge_PartialSuccess() {
+        // given
+        ChallengeMember successMember = createChallengeMember(member1, false, 5);
+        ChallengeMember failMember1 = createChallengeMember(member2, false, 3);
+        ChallengeMember failMember2 = createChallengeMember(member3, true, 2);  // 호스트이지만 실패
+        List<ChallengeMember> ongoingMembers = List.of(successMember, failMember1, failMember2);
+
+        when(challengeMemberRepository.findAllByChallengeIdAndChallengeMemberStatus(
+            1L, ChallengeMemberStatus.ONGOING)).thenReturn(ongoingMembers);
+
+        // when
+        challengeSettlementService.settleChallenge(challenge);
+
+        // then — 성공 1명에게 300포인트 전액 지급
+        assertThat(successMember.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.SUCCESS);
+        assertThat(failMember1.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.FAIL);
+        assertThat(failMember2.getChallengeMemberStatus()).isEqualTo(ChallengeMemberStatus.FAIL);
+        verify(pointService, times(1)).grantChallengePoints(
+            eq(member1), eq(challenge), eq(300), eq(PointName.SUCCESS_CHALLENGE));
+        assertThat(challenge.getIsSettled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("전원 실패 — 포인트 분배 없음, collectedPoint 소멸")
+    void settleChallenge_AllFail() {
+        // given
+        List<ChallengeMember> ongoingMembers = List.of(
+            createChallengeMember(member1, false, 2),
+            createChallengeMember(member2, false, 0),
+            createChallengeMember(member3, true, 4)   // 호스트이지만 목표 미달
+        );
+
+        when(challengeMemberRepository.findAllByChallengeIdAndChallengeMemberStatus(
+            1L, ChallengeMemberStatus.ONGOING)).thenReturn(ongoingMembers);
+
+        // when
+        challengeSettlementService.settleChallenge(challenge);
+
+        // then — 전원 FAIL, 포인트 지급 없음
+        assertThat(ongoingMembers).allMatch(
+            m -> m.getChallengeMemberStatus() == ChallengeMemberStatus.FAIL);
+        verifyNoInteractions(pointService);
+        assertThat(challenge.getIsSettled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("중복 정산 방지 — isSettled가 true이면 정산 스킵")
+    void settleChallenge_AlreadySettled() {
+        // given
+        Challenge settledChallenge = Challenge.builder()
+            .id(2L)
+            .totalGoalDay(5)
+            .collectedPoint(300)
+            .isSettled(true)
+            .build();
+
+        // when
+        challengeSettlementService.settleChallenge(settledChallenge);
+
+        // then — Repository, PointService 모두 호출되지 않음
+        verifyNoInteractions(challengeMemberRepository, pointService);
+    }
+
+    @Test
+    @DisplayName("나머지 포인트 처리 — 나누어떨어지지 않는 경우 나머지 소멸")
+    void settleChallenge_RemainderPointDiscarded() {
+        // given — collectedPoint 300, 성공 멤버 2명 → 1인당 150, 나머지 0
+        //         collectedPoint 를 301로 변경 → 1인당 150, 나머지 1 소멸
+        Challenge oddChallenge = Challenge.builder()
+            .id(3L)
+            .totalGoalDay(5)
+            .collectedPoint(301)
+            .isSettled(false)
+            .build();
+
+        List<ChallengeMember> ongoingMembers = List.of(
+            createChallengeMember(member1, false, 5),
+            createChallengeMember(member2, false, 6)
+        );
+
+        when(challengeMemberRepository.findAllByChallengeIdAndChallengeMemberStatus(
+            3L, ChallengeMemberStatus.ONGOING)).thenReturn(ongoingMembers);
+
+        // when
+        challengeSettlementService.settleChallenge(oddChallenge);
+
+        // then — 1인당 150포인트 (301/2=150, 나머지 1 소멸)
+        verify(pointService, times(2)).grantChallengePoints(
+            any(Member.class), eq(oddChallenge), eq(150), eq(PointName.SUCCESS_CHALLENGE));
+        assertThat(oddChallenge.getIsSettled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ONGOING 멤버가 없는 경우 — 정산 건너뛰고 isSettled 처리")
+    void settleChallenge_NoOngoingMembers() {
+        // given
+        when(challengeMemberRepository.findAllByChallengeIdAndChallengeMemberStatus(
+            1L, ChallengeMemberStatus.ONGOING)).thenReturn(Collections.emptyList());
+
+        // when
+        challengeSettlementService.settleChallenge(challenge);
+
+        // then
+        verifyNoInteractions(pointService);
+        assertThat(challenge.getIsSettled()).isTrue();
+    }
+
+    /**
+     * 테스트용 ChallengeMember 생성 헬퍼 메서드
+     */
+    private ChallengeMember createChallengeMember(Member member, boolean isHost, int successDays) {
+        return ChallengeMember.builder()
+            .member(member)
+            .challenge(challenge)
+            .isHost(isHost)
+            .successDays(successDays)
+            .challengeMemberStatus(ChallengeMemberStatus.ONGOING)
+            .isFeedUpload(false)
+            .build();
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- closed #88 

## 🍬 기능 설명
- 챌린지 종료(`END`) 시 참여 멤버의 성공/실패를 판정하고, 모인 포인트(`collectedPoint`)를 성공 멤버에게 균등 분배하는 정산 기능 구현
- `ChallengeSettlementService`를 신규 생성하여 정산 로직을 분리
- 기존 `ChallengeStatusScheduler`에서 상태가 `END`로 전환될 때 정산을 자동 트리거
- `Challenge.isSettled` 필드를 추가하여 중복 정산 방지
- 호스트 보너스 포인트 지급 틀은 구현했으나, 정책(금액 등)은 추후 논의 필요

## 🤔 코드 리뷰에서 집중적으로 볼 내용
- `ChallengeSettlementService.settleChallenge()` — 정산 흐름 전체 (판정 → 분배 → 완료 표시)
- 포인트 균등 분배 시 나머지 포인트 소멸 처리가 적절한지
- `ChallengeStatusScheduler`에서 정산 호출 위치 — 상태 변경과 같은 트랜잭션 내에서 처리되는 것이 맞는지
- `HOST_BONUS_POINT = 0`으로 임시 설정한 부분 — 추후 정책 확정 시 변경 방법

## ⭐ 기타 사항
- 호스트 보너스 정책(지급 조건, 금액)은 현재 미확정 상태이므로 논의 안건 상정 필요
- 전원 실패 시 `collectedPoint`는 소멸 처리됨
- 균등 분배 시 나누어떨어지지 않는 나머지 포인트는 소멸 처리됨