### PR TITLE
[Feat] 챌린지 ID별 피드 조회 및 isMyFeed 플래그 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ out/
 ### Claude Code ###
 CLAUDE.md
 claude/*
+.claude
 
 ### Logs ###
 logs

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,12 @@ dependencyManagement {
 }
 
 dependencies {
+  // Spring Boot Starter
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-security'
   implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
   compileOnly 'org.projectlombok:lombok'
   runtimeOnly 'com.mysql:mysql-connector-j'
   runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/controller/AchievementController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/controller/AchievementController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,8 +50,10 @@ public class AchievementController {
     public BaseResponse<SliceResponseDTO<PreviewFeedResDTO>> getFeedByCategory(
         @PathVariable(name = "category") Category category,
         @RequestParam(defaultValue = "4") Integer size,
-        @RequestParam("page") Integer page
+        @RequestParam("page") Integer page,
+        Authentication authentication
     ) {
-        return new BaseResponse<>(achievementService.getFeedsByCategory(category, page, size));
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(achievementService.getFeedsByCategory(category, page, size, memberId));
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementService.java
@@ -23,5 +23,5 @@ public interface AchievementService {
      * @return 해당 카테고리와 페이지에 해당하는 챌린지 피드 목록 (SliceResponseDTO)
      */
     SliceResponseDTO<PreviewFeedResDTO> getFeedsByCategory(Category category, Integer page,
-        Integer size);
+        Integer size, Long memberId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementService.java
@@ -20,6 +20,8 @@ public interface AchievementService {
      *
      * @param category 조회할 카테고리
      * @param page     페이지 번호
+     * @param size     페이지 크기
+     * @param memberId 요청한 사용자 ID (isMyFeed 계산용)
      * @return 해당 카테고리와 페이지에 해당하는 챌린지 피드 목록 (SliceResponseDTO)
      */
     SliceResponseDTO<PreviewFeedResDTO> getFeedsByCategory(Category category, Integer page,

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementServiceImpl.java
@@ -54,7 +54,7 @@ public class AchievementServiceImpl implements AchievementService {
 
     @Override
     public SliceResponseDTO<PreviewFeedResDTO> getFeedsByCategory(Category category, Integer page,
-        Integer size) {
+        Integer size, Long memberId) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
 
         Slice<Feed> feedsPage;
@@ -63,6 +63,6 @@ public class AchievementServiceImpl implements AchievementService {
         } else {
             feedsPage = feedRepository.findAllByChallenge_Category(category, pageable);
         }
-        return FeedAssembler.toSliceResponseDTO(feedsPage);
+        return FeedAssembler.toSliceResponseDTO(feedsPage, memberId);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
@@ -152,6 +152,23 @@ public class FeedController {
         return new BaseResponse<>(feedService.getChallengeFeedList(challengeId, page, size));
     }
 
+    @Operation(summary = "내 챌린지 피드 조회", description = "내가 참여한 챌린지에서 내가 작성한 피드 목록을 최신순으로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "내 챌린지 피드 조회 성공",
+            content = @Content(schema = @Schema(implementation = SliceResponseDTO.class))),
+        @ApiResponse(responseCode = "400", description = "존재하지 않는 챌린지 또는 미참여 챌린지"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/challenge/{challengeId}/my")
+    public BaseResponse<SliceResponseDTO<PreviewFeedResDTO>> getMyChallengeFeedList(
+        @Parameter(description = "챌린지 ID", example = "1") @PathVariable Long challengeId,
+        @Parameter(description = "페이지 번호", example = "0") @Min(0) @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "페이지 크기", example = "10") @Min(1) @Max(10) @RequestParam(defaultValue = "10") int size,
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(feedService.getMyChallengeFeedList(challengeId, memberId, page, size));
+    }
+
     @Operation(summary = "피드 검색", description = "피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "피드 검색 성공",

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
@@ -137,6 +137,21 @@ public class FeedController {
         return new BaseResponse<>(feedService.getMyFeedList(memberId, category, page, size));
     }
 
+    @Operation(summary = "챌린지 피드 목록 조회", description = "특정 챌린지에 등록된 전체 피드 목록을 최신순으로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "챌린지 피드 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = SliceResponseDTO.class))),
+        @ApiResponse(responseCode = "400", description = "존재하지 않는 챌린지"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/challenge/{challengeId}")
+    public BaseResponse<SliceResponseDTO<PreviewFeedResDTO>> getChallengeFeedList(
+        @Parameter(description = "챌린지 ID", example = "1") @PathVariable Long challengeId,
+        @Parameter(description = "페이지 번호", example = "0") @Min(0) @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "페이지 크기", example = "10") @Min(1) @Max(10) @RequestParam(defaultValue = "10") int size) {
+        return new BaseResponse<>(feedService.getChallengeFeedList(challengeId, page, size));
+    }
+
     @Operation(summary = "피드 검색", description = "피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "피드 검색 성공",

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/controller/FeedController.java
@@ -148,8 +148,11 @@ public class FeedController {
     public BaseResponse<SliceResponseDTO<PreviewFeedResDTO>> getChallengeFeedList(
         @Parameter(description = "챌린지 ID", example = "1") @PathVariable Long challengeId,
         @Parameter(description = "페이지 번호", example = "0") @Min(0) @RequestParam(defaultValue = "0") int page,
-        @Parameter(description = "페이지 크기", example = "10") @Min(1) @Max(10) @RequestParam(defaultValue = "10") int size) {
-        return new BaseResponse<>(feedService.getChallengeFeedList(challengeId, page, size));
+        @Parameter(description = "페이지 크기", example = "10") @Min(1) @Max(10) @RequestParam(defaultValue = "10") int size,
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(
+            feedService.getChallengeFeedList(challengeId, memberId, page, size));
     }
 
     @Operation(summary = "내 챌린지 피드 조회", description = "내가 참여한 챌린지에서 내가 작성한 피드 목록을 최신순으로 조회합니다.")
@@ -166,7 +169,8 @@ public class FeedController {
         @Parameter(description = "페이지 크기", example = "10") @Min(1) @Max(10) @RequestParam(defaultValue = "10") int size,
         Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
-        return new BaseResponse<>(feedService.getMyChallengeFeedList(challengeId, memberId, page, size));
+        return new BaseResponse<>(
+            feedService.getMyChallengeFeedList(challengeId, memberId, page, size));
     }
 
     @Operation(summary = "피드 검색", description = "피드 내용(review)을 키워드로 검색하고, 등록 시간 기준으로 정렬합니다.")

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/FeedAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/FeedAssembler.java
@@ -27,23 +27,25 @@ public class FeedAssembler {
             .build();
     }
 
-    public static PreviewFeedResDTO toPreviewFeedResDTO(Feed feed) {
+    public static PreviewFeedResDTO toPreviewFeedResDTO(Feed feed, Long memberId) {
         return PreviewFeedResDTO.builder()
             .feedId(feed.getId())
             .feedUrl(feed.getFeedUrl())
             .day(ChronoUnit.DAYS.between(feed.getUploadDate(), feed.getChallenge().getStartDate()))
+            .isMyFeed(feed.getChallengeMember().getMember().getId().equals(memberId))
             .build();
     }
 
-    public static List<PreviewFeedResDTO> toPreviewFeedResDTOList(List<Feed> feedList) {
-        return feedList.stream().map(FeedAssembler::toPreviewFeedResDTO).toList();
+    public static List<PreviewFeedResDTO> toPreviewFeedResDTOList(List<Feed> feedList,
+        Long memberId) {
+        return feedList.stream().map(feed -> toPreviewFeedResDTO(feed, memberId)).toList();
     }
 
 
     /**
      * Feed 엔티티를 FeedDetailResDTO로 변환
      */
-    public static FeedDetailResDTO toFeedDetailResDTO(Feed feed, boolean isLiked) {
+    public static FeedDetailResDTO toFeedDetailResDTO(Feed feed, boolean isLiked, Long memberId) {
         return FeedDetailResDTO.builder()
             .feedId(feed.getId())
             .memberInfo(toMemberInfoDTO(feed))
@@ -55,6 +57,7 @@ public class FeedAssembler {
             .uploadDate(feed.getUploadDate())
             .likeCount((long) feed.getFeedLikes().size())
             .isLiked(isLiked)
+            .isMyFeed(feed.getChallengeMember().getMember().getId().equals(memberId))
             .createdAt(feed.getCreatedAt())
             .updatedAt(feed.getUpdatedAt())
             .build();
@@ -77,8 +80,10 @@ public class FeedAssembler {
     /**
      * Spring Data Slice를 SliceResponseDTO로 변환
      */
-    public static SliceResponseDTO<PreviewFeedResDTO> toSliceResponseDTO(Slice<Feed> feedSlice) {
-        List<PreviewFeedResDTO> feedDtoList = toPreviewFeedResDTOList(feedSlice.getContent());
+    public static SliceResponseDTO<PreviewFeedResDTO> toSliceResponseDTO(Slice<Feed> feedSlice,
+        Long memberId) {
+        List<PreviewFeedResDTO> feedDtoList = toPreviewFeedResDTOList(feedSlice.getContent(),
+            memberId);
         return SliceResponseDTO.<PreviewFeedResDTO>builder()
             .content(feedDtoList)
             .number(feedSlice.getNumber())

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/FeedAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/FeedAssembler.java
@@ -31,7 +31,7 @@ public class FeedAssembler {
         return PreviewFeedResDTO.builder()
             .feedId(feed.getId())
             .feedUrl(feed.getFeedUrl())
-            .day(ChronoUnit.DAYS.between(feed.getUploadDate(), feed.getChallenge().getStartDate()))
+            .day(ChronoUnit.DAYS.between(feed.getChallenge().getStartDate(), feed.getUploadDate()))
             .isMyFeed(feed.getChallengeMember().getMember().getId().equals(memberId))
             .build();
     }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/res/FeedDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/res/FeedDetailResDTO.java
@@ -42,6 +42,9 @@ public class FeedDetailResDTO {
     @Schema(description = "현재 사용자의 좋아요 여부", example = "true")
     private Boolean isLiked;
 
+    @Schema(description = "내가 작성한 피드 여부", example = "false")
+    private Boolean isMyFeed;
+
     @Schema(description = "생성 시간")
     private LocalDateTime createdAt;
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/res/PreviewFeedResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/dto/res/PreviewFeedResDTO.java
@@ -17,4 +17,7 @@ public class PreviewFeedResDTO {
     
     @Schema(description = "챌린지 시작일로부터 경과일", example = "15")
     private Long day;
+
+    @Schema(description = "내가 작성한 피드 여부", example = "true")
+    private Boolean isMyFeed;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
@@ -43,4 +43,15 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
      * @return 조회된 피드 목록 (Slice)
      */
     Slice<Feed> findAllByChallenge_IdOrderByCreatedAtDesc(Long challengeId, Pageable pageable);
+
+    /**
+     * 특정 챌린지에서 특정 멤버가 작성한 피드를 최신순으로 조회 (인증 피드 조회용)
+     *
+     * @param challengeId 챌린지 ID
+     * @param memberId    사용자 ID
+     * @param pageable    페이징 정보
+     * @return 조회된 피드 목록 (Slice)
+     */
+    Slice<Feed> findAllByChallenge_IdAndChallengeMember_Member_IdOrderByCreatedAtDesc(
+        Long challengeId, Long memberId, Pageable pageable);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
@@ -34,4 +34,13 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
 
     @Query("SELECT COUNT(f) FROM Feed f WHERE f.challengeMember.member.id = :memberId")
     Long countByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 챌린지의 전체 피드를 최신순으로 조회
+     *
+     * @param challengeId 챌린지 ID
+     * @param pageable    페이징 정보
+     * @return 조회된 피드 목록 (Slice)
+     */
+    Slice<Feed> findAllByChallenge_IdOrderByCreatedAtDesc(Long challengeId, Pageable pageable);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
@@ -88,6 +88,7 @@ public interface FeedService {
      * 특정 챌린지의 전체 피드 목록을 조회합니다.
      *
      * @param challengeId 조회할 챌린지 ID
+     * @param memberId    요청한 사용자 ID (isMyFeed 계산용)
      * @param page        페이지 번호
      * @param size        페이지 크기
      * @return 슬라이스된 피드 목록 (무한 스크롤용)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
@@ -93,4 +93,17 @@ public interface FeedService {
      * @return 슬라이스된 피드 목록 (무한 스크롤용)
      */
     SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, int page, int size);
+
+    /**
+     * 내가 참여한 챌린지에서 내가 작성한 피드 목록을 조회합니다.
+     * 챌린지 참여자만 조회할 수 있습니다.
+     *
+     * @param challengeId 조회할 챌린지 ID
+     * @param memberId    요청한 사용자 ID
+     * @param page        페이지 번호
+     * @param size        페이지 크기
+     * @return 슬라이스된 내 피드 목록 (무한 스크롤용)
+     */
+    SliceResponseDTO<PreviewFeedResDTO> getMyChallengeFeedList(Long challengeId, Long memberId,
+        int page, int size);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
@@ -92,11 +92,11 @@ public interface FeedService {
      * @param size        페이지 크기
      * @return 슬라이스된 피드 목록 (무한 스크롤용)
      */
-    SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, int page, int size);
+    SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, Long memberId,
+        int page, int size);
 
     /**
-     * 내가 참여한 챌린지에서 내가 작성한 피드 목록을 조회합니다.
-     * 챌린지 참여자만 조회할 수 있습니다.
+     * 내가 참여한 챌린지에서 내가 작성한 피드 목록을 조회합니다. 챌린지 참여자만 조회할 수 있습니다.
      *
      * @param challengeId 조회할 챌린지 ID
      * @param memberId    요청한 사용자 ID

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedService.java
@@ -83,4 +83,14 @@ public interface FeedService {
      * @return 슬라이스된 피드 검색 결과 (무한 스크롤용)
      */
     SliceResponseDTO<PreviewFeedResDTO> searchFeeds(Long memberId, FeedSearchReqDTO requestDTO);
+
+    /**
+     * 특정 챌린지의 전체 피드 목록을 조회합니다.
+     *
+     * @param challengeId 조회할 챌린지 ID
+     * @param page        페이지 번호
+     * @param size        페이지 크기
+     * @return 슬라이스된 피드 목록 (무한 스크롤용)
+     */
+    SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, int page, int size);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -202,6 +202,29 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
+    public SliceResponseDTO<PreviewFeedResDTO> getMyChallengeFeedList(Long challengeId,
+        Long memberId, int page, int size) {
+        // 챌린지 존재 여부 확인
+        if (!challengeRepository.existsById(challengeId)) {
+            throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
+        }
+
+        // 챌린지 참여 여부 확인
+        challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_JOINED_CHALLENGE));
+
+        // 최신순 페이징 처리
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 챌린지 ID + 멤버 ID 기준 피드 조회
+        Slice<Feed> feedSlice =
+            feedRepository.findAllByChallenge_IdAndChallengeMember_Member_IdOrderByCreatedAtDesc(
+                challengeId, memberId, pageable);
+
+        return FeedAssembler.toSliceResponseDTO(feedSlice);
+    }
+
+    @Override
     public SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, int page,
         int size) {
         // 챌린지 존재 여부 확인

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.FeedAssembler;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedCreateReqDTO;
@@ -63,7 +62,7 @@ public class FeedServiceImpl implements FeedService {
         }
 
         // SliceResponseDTO로 변환
-        return FeedAssembler.toSliceResponseDTO(feedSlice);
+        return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
     }
 
     @Override
@@ -76,7 +75,7 @@ public class FeedServiceImpl implements FeedService {
         boolean isLiked = feedLikeRepository.existsByFeed_IdAndMember_Id(feedId, memberId);
 
         // FeedAssembler를 사용하여 FeedDetailResDTO 생성
-        return FeedAssembler.toFeedDetailResDTO(feed, isLiked);
+        return FeedAssembler.toFeedDetailResDTO(feed, isLiked, memberId);
     }
 
     @Override
@@ -198,7 +197,7 @@ public class FeedServiceImpl implements FeedService {
         }
 
         // SliceResponseDTO로 변환하여 반환
-        return FeedAssembler.toSliceResponseDTO(feedSlice);
+        return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
     }
 
     @Override
@@ -221,12 +220,12 @@ public class FeedServiceImpl implements FeedService {
             feedRepository.findAllByChallenge_IdAndChallengeMember_Member_IdOrderByCreatedAtDesc(
                 challengeId, memberId, pageable);
 
-        return FeedAssembler.toSliceResponseDTO(feedSlice);
+        return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
     }
 
     @Override
-    public SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, int page,
-        int size) {
+    public SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, Long memberId,
+        int page, int size) {
         // 챌린지 존재 여부 확인
         if (!challengeRepository.existsById(challengeId)) {
             throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
@@ -239,7 +238,7 @@ public class FeedServiceImpl implements FeedService {
         Slice<Feed> feedSlice = feedRepository.findAllByChallenge_IdOrderByCreatedAtDesc(
             challengeId, pageable);
 
-        return FeedAssembler.toSliceResponseDTO(feedSlice);
+        return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
     }
 
     @Override
@@ -260,6 +259,6 @@ public class FeedServiceImpl implements FeedService {
         );
 
         // SliceResponseDTO로 변환하여 반환
-        return FeedAssembler.toSliceResponseDTO(feedSlice);
+        return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.FeedAssembler;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedCreateReqDTO;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedListReqDTO;
@@ -26,6 +28,8 @@ import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMember
 import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
 import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.SliceResponseDTO;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 
@@ -38,6 +42,7 @@ public class FeedServiceImpl implements FeedService {
     private final FeedLikeRepository feedLikeRepository;
     private final ChallengeMemberRepository challengeMemberRepository;
     private final MemberRepository memberRepository;
+    private final ChallengeRepository challengeRepository;
     private final S3Service s3Service;
 
     @Override
@@ -193,6 +198,24 @@ public class FeedServiceImpl implements FeedService {
         }
 
         // SliceResponseDTO로 변환하여 반환
+        return FeedAssembler.toSliceResponseDTO(feedSlice);
+    }
+
+    @Override
+    public SliceResponseDTO<PreviewFeedResDTO> getChallengeFeedList(Long challengeId, int page,
+        int size) {
+        // 챌린지 존재 여부 확인
+        if (!challengeRepository.existsById(challengeId)) {
+            throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
+        }
+
+        // 최신순 페이징 처리
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 챌린지 ID 기준 피드 조회
+        Slice<Feed> feedSlice = feedRepository.findAllByChallenge_IdOrderByCreatedAtDesc(
+            challengeId, pageable);
+
         return FeedAssembler.toSliceResponseDTO(feedSlice);
     }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.feed.service;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -91,6 +92,16 @@ public class FeedServiceImpl implements FeedService {
         // 작성자가 해당 챌린지의 참여자인지 확인
         if (!challengeMember.getMember().getId().equals(memberId)) {
             throw new IllegalArgumentException("해당 챌린지의 참여자만 피드를 작성할 수 있습니다.");
+        }
+
+        // 챌린지 시작일 이전에는 피드 작성 불가
+        if (LocalDate.now().isBefore(challengeMember.getChallenge().getStartDate())) {
+            throw new BaseException(BaseResponseCode.CHALLENGE_NOT_STARTED);
+        }
+
+        // 챌린지 종료일 이후에는 피드 작성 불가
+        if (LocalDate.now().isAfter(challengeMember.getChallenge().getFinishDate())) {
+            throw new BaseException(BaseResponseCode.CHALLENGE_ENDED);
         }
 
         // 파일이 없거나 빈 파일인 경우 예외 발생

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
@@ -48,7 +48,7 @@ public class MemberAssembler {
             .build();
     }
 
-public static MemberNicknameResDTO toNicknameResDTO(Member member) {
+    public static MemberNicknameResDTO toNicknameResDTO(Member member) {
         return MemberNicknameResDTO.builder()
             .nickName(member.getNickName())
             .build();

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -49,7 +49,9 @@ public enum BaseResponseCode {
     ALREADY_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0005", "이미 참여한 챌린지입니다"),
     CHALLENGE_ENDED(HttpStatus.BAD_REQUEST, "C0006", "종료된 챌린지입니다"),
     ALREADY_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0007", "이미 찜한 챌린지입니다"),
-    NOT_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0008", "찜하지 않은 챌린지입니다");
+    NOT_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0008", "찜하지 않은 챌린지입니다"),
+    NOT_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0009", "참여하지 않은 챌린지입니다"),
+    CHALLENGE_NOT_ENDED(HttpStatus.BAD_REQUEST, "C0010", "완료되지 않은 챌린지입니다");
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -51,7 +51,8 @@ public enum BaseResponseCode {
     ALREADY_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0007", "이미 찜한 챌린지입니다"),
     NOT_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0008", "찜하지 않은 챌린지입니다"),
     NOT_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0009", "참여하지 않은 챌린지입니다"),
-    CHALLENGE_NOT_ENDED(HttpStatus.BAD_REQUEST, "C0010", "완료되지 않은 챌린지입니다");
+    CHALLENGE_NOT_ENDED(HttpStatus.BAD_REQUEST, "C0010", "완료되지 않은 챌린지입니다"),
+    CHALLENGE_NOT_STARTED(HttpStatus.BAD_REQUEST, "C0011", "아직 시작하지 않은 챌린지입니다");
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드


### PR DESCRIPTION
## 📌 이슈 번호

- closed #102 

## 🍬 기능 설명

- `GET /feed/challenge/{challengeId}` — 특정 챌린지에 등록된 전체 피드 목록을 최신순으로 조회
- `GET /feed/challenge/{challengeId}/my` — 내가 참여한 챌린지에서 내가 작성한 피드 목록을 최신순으로 조회 (참여 여부 검증)
- `PreviewFeedResDTO`, `FeedDetailResDTO` 응답에 `isMyFeed` 플래그 추가
- `BaseResponseCode`에 `NOT_JOINED_CHALLENGE(C0009)`, `CHALLENGE_NOT_ENDED(C0010)` 예외 코드 추가

## 🤔 코드 리뷰에서 집중적으로 볼 내용

**isMyFeed 플래그 반영 범위**

`isMyFeed` 추가로 `FeedAssembler`의 `toPreviewFeedResDTO`, `toSliceResponseDTO`, `toFeedDetailResDTO` 시그니처가 모두 변경되었습니다.
기존에 이 메서드를 사용하던 `AchievementServiceImpl`, `MemberAssembler`(마이페이지)까지 파급 범위가 넓어졌습니다.
멤버와 달성 모두 추후 API 분리 대상 기능으로 리팩터링 시 이를 고려해야 합니다. 

```java
// 변경 전
FeedAssembler.toSliceResponseDTO(feedSlice);

// 변경 후
FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
```

**참여 여부 검증 방식**

`GET /feed/challenge/{challengeId}/my`에서 `ChallengeMemberRepository.findByChallengeIdAndMemberId`로 참여 여부를 확인합니다.
챌린지 존재 여부 → 참여 여부 순서로 검증합니다.

```java
if (!challengeRepository.existsById(challengeId)) {
    throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
}
challengeMemberRepository.findByChallengeIdAndMemberId(challengeId, memberId)
    .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_JOINED_CHALLENGE));
```

## ⭐ 기타 사항

- 두 신규 API 모두 기존 `PreviewFeedResDTO`를 재사용하여 별도 DTO 추가 없이 구현
- `CHALLENGE_NOT_ENDED(C0010)` 코드는 향후 완료된 챌린지 전용 기능 구현 시 활용 예정