### PR TITLE
[Fix] 챌린지 상세 작성자명 누락 및 ChallengeMember 상태 미변경 버그 수정

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -63,6 +63,7 @@ jobs:
   setup-docker-compose:
     name: Setup Docker Compose on Server
     runs-on: ubuntu-latest
+    needs: setup-docker
     steps:
       - name: Install Docker Compose plugin if missing
         uses: appleboy/ssh-action@v1.0.0
@@ -104,7 +105,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [setup-docker-compose, setup-network]
+    needs: [setup-make, setup-docker-compose, setup-network]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -104,7 +104,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: setup-docker-compose
+    needs: [setup-docker-compose, setup-network]
 
     steps:
       - name: Checkout code

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/ChallengeAssembler.java
@@ -89,7 +89,7 @@ public class ChallengeAssembler {
 
     public static ChallengeDetailResDTO toChallengeDetailResDTO(
         Challenge challenge, boolean isJoinable, boolean isLiked, ChallengeMemberStatus status,
-        Float progress, Integer usedPoint, Integer earnedPoint
+        Float progress, Integer usedPoint, Integer earnedPoint, String hostName
     ) {
         List<String> infoImageUrls = challenge.getInfoImages().stream()
             .sorted((a, b) -> a.getImageOrder().compareTo(b.getImageOrder()))
@@ -126,6 +126,7 @@ public class ChallengeAssembler {
             .progress(progress)
             .usedPoint(usedPoint)
             .earnedPoint(earnedPoint)
+            .hostName(hostName)
             .build();
     }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/dto/res/ChallengeDetailResDTO.java
@@ -31,4 +31,5 @@ public class ChallengeDetailResDTO {
     private Float progress;
     private Integer usedPoint;
     private Integer earnedPoint;
+    private String hostName; // 챌린지 개설자(호스트) 닉네임
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -390,8 +390,13 @@ public class ChallengeServiceImpl implements ChallengeService {
             earnedPoint = calculatePointSum(pointLogs, PointStatus.EARN);
         }
 
+        // 호스트(챌린지 개설자) 닉네임 조회
+        String hostName = challengeMemberRepository.findByChallengeIdAndIsHost(challengeId, true)
+            .map(host -> host.getMember().getNickName())
+            .orElse(null);
+
         return ChallengeAssembler.toChallengeDetailResDTO(
-            challenge, isJoinable, isLiked, status, progress, usedPoint, earnedPoint
+            challenge, isJoinable, isLiked, status, progress, usedPoint, earnedPoint, hostName
         );
     }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeStatusScheduler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeStatusScheduler.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
+import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
+import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMemberRepository;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
 
 @Slf4j
@@ -19,6 +22,7 @@ public class ChallengeStatusScheduler {
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeSettlementService challengeSettlementService;
+    private final ChallengeMemberRepository challengeMemberRepository;
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
     public void updateChallengeStatuses() {
@@ -41,6 +45,17 @@ public class ChallengeStatusScheduler {
                 updatedCount++;
                 log.debug("챌린지 ID: {}, 상태 변경: {} -> {}",
                     challenge.getId(), currentStatus, calculatedStatus);
+
+                // NOT_YET → IN_PROGRESS 전환 시 ChallengeMember 상태 동기화
+                if (calculatedStatus == ChallengeStatus.IN_PROGRESS) {
+                    List<ChallengeMember> notYetMembers = challengeMemberRepository
+                        .findAllByChallengeIdAndChallengeMemberStatus(
+                            challenge.getId(), ChallengeMemberStatus.NOT_YET);
+                    notYetMembers.forEach(member ->
+                        member.updateChallengeMemberStatus(ChallengeMemberStatus.ONGOING));
+                    log.debug("챌린지 ID: {}, ChallengeMember {}명 NOT_YET → ONGOING 전환",
+                        challenge.getId(), notYetMembers.size());
+                }
 
                 // END 상태로 전환된 챌린지에 대해 포인트 정산 수행
                 if (calculatedStatus == ChallengeStatus.END) {

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/ChallengeMemberRepository.java
@@ -22,6 +22,9 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
     // 챌린지-멤버 단건 조회
     Optional<ChallengeMember> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 
+    // 챌린지 호스트 조회
+    Optional<ChallengeMember> findByChallengeIdAndIsHost(Long challengeId, Boolean isHost);
+
     // 특정 챌린지의 특정 상태 멤버 목록 조회 (정산 시 ONGOING 멤버 조회용)
     List<ChallengeMember> findAllByChallengeIdAndChallengeMemberStatus(
         Long challengeId, ChallengeMemberStatus challengeMemberStatus);


### PR DESCRIPTION
## 📌 이슈 번호

- closed #104 

## 🍬 기능 설명

- **챌린지 상세 조회 응답에 작성자명(`hostName`) 추가**
  - `ChallengeDetailResDTO`에 `hostName` 필드 추가
  - `ChallengeMemberRepository`에 `isHost` 기반 호스트 조회 메서드 추가
  - `getChallengeDetail()`에서 `isHost = true`인 멤버의 닉네임을 조회하여 응답에 포함
  - 호스트가 없는 경우 `null` 반환 (데이터 정합성 오류에 안전하게 대응)

- **챌린지 시작 시 `ChallengeMember` 상태 동기화 버그 수정**
  - 기존: `ChallengeStatusScheduler`가 `Challenge.status`는 `NOT_YET → IN_PROGRESS`로 변경하지만, 연결된 `ChallengeMember.challengeMemberStatus`는 `NOT_YET`으로 유지됨
  - 수정: `NOT_YET → IN_PROGRESS` 전환 시, 해당 챌린지의 `ChallengeMember` 중 `NOT_YET` 상태인 레코드를 `ONGOING`으로 일괄 업데이트

## 🤔 코드 리뷰에서 집중적으로 볼 내용

```java
// ChallengeStatusScheduler.java
// NOT_YET → IN_PROGRESS 전환 시 ChallengeMember 상태 동기화
if (calculatedStatus == ChallengeStatus.IN_PROGRESS) {
    List<ChallengeMember> notYetMembers = challengeMemberRepository
        .findAllByChallengeIdAndChallengeMemberStatus(
            challenge.getId(), ChallengeMemberStatus.NOT_YET);
    notYetMembers.forEach(member ->
        member.updateChallengeMemberStatus(ChallengeMemberStatus.ONGOING));
}
```
- 스케줄러 내에서 챌린지 수만큼 ChallengeMember 조회가 추가로 발생합니다. 챌린지 수가 많아질 경우 N+1 이슈가 될 수 있어 추후 배치 쿼리로 개선이 필요할 수 있습니다.

```java
// ChallengeServiceImpl.java
String hostName = challengeMemberRepository.findByChallengeIdAndIsHost(challengeId, true)
    .map(host -> host.getMember().getNickName())
    .orElse(null);
```
- `host.getMember()`는 `LAZY` 로딩이므로 트랜잭션 내에서 호출됩니다. 현재 `@Transactional` 범위 안에 있어 문제없지만, 추후 분리 시 주의가 필요합니다.

## ⭐ 기타 사항

- `ChallengeMember.updateChallengeMemberStatus()`는 기존에 정산 시 사용하던 메서드를 재사용하였습니다.
- `findAllByChallengeIdAndChallengeMemberStatus()`도 기존 메서드를 재사용하였습니다.
