### PR TITLE
[Feat] 마이페이지 프로필 이미지 설정 기능 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -175,7 +175,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     private void saveInfoImages(Challenge challenge, List<MultipartFile> infoImages) {
         for (int i = 0; i < infoImages.size(); i++) {
-            String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_MAIN, infoImages.get(i));
+            // challenge/{challengeId}/main/filename 구조로 업로드
+            String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE,
+                challenge.getId() + "/main", infoImages.get(i));
             ChallengeInfoImage infoImage = ChallengeInfoImage.builder()
                 .imageUrl(imageUrl)
                 .imageOrder(i + 1)
@@ -187,7 +189,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     private void saveCertImages(Challenge challenge, List<MultipartFile> certImages) {
         for (int i = 0; i < certImages.size(); i++) {
-            String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE_CERT, certImages.get(i));
+            // challenge/{challengeId}/cert/filename 구조로 업로드
+            String imageUrl = s3Service.uploadFile(UploadPath.CHALLENGE,
+                challenge.getId() + "/cert", certImages.get(i));
             ChallengeCertImage certImage = ChallengeCertImage.builder()
                 .imageUrl(imageUrl)
                 .imageOrder(i + 1)
@@ -218,9 +222,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 모집중인 챌린지 목록을 조회합니다.
-     * - 시작일이 오늘 이후인 챌린지를 대상으로 조회
-     * - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
+     * 모집중인 챌린지 목록을 조회합니다. - 시작일이 오늘 이후인 챌린지를 대상으로 조회 - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> getOpenChallengeList(
@@ -246,9 +248,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 모집마감된 챌린지 목록을 조회합니다.
-     * - 시작일이 오늘 이전인 챌린지를 대상으로 조회
-     * - 최근 마감순(startDate DESC)으로 정렬
+     * 모집마감된 챌린지 목록을 조회합니다. - 시작일이 오늘 이전인 챌린지를 대상으로 조회 - 최근 마감순(startDate DESC)으로 정렬
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> getClosedChallengeList(
@@ -274,9 +274,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 찜한 챌린지 목록을 조회합니다.
-     * - 내가 찜한 챌린지 목록을 조회
-     * - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
+     * 찜한 챌린지 목록을 조회합니다. - 내가 찜한 챌린지 목록을 조회 - 카테고리 필터링 및 정렬 기능 제공 (마감 임박순/최신순)
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> getLikedChallengeList(Long memberId,
@@ -303,12 +301,9 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 나의 챌린지 목록을 조회합니다.
-     * - 내가 참여한 챌린지를 상태별로 조회
-     * - ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
-     * - SUCCESS: ChallengeMemberStatus = SUCCESS
-     * - FAIL: ChallengeMemberStatus = FAIL
-     * - 정렬은 참여일(createdAt) 내림차순으로 고정
+     * 나의 챌린지 목록을 조회합니다. - 내가 참여한 챌린지를 상태별로 조회 - ONGOING: ChallengeMemberStatus = ONGOING 또는 NOT_YET
+     * - SUCCESS: ChallengeMemberStatus = SUCCESS - FAIL: ChallengeMemberStatus = FAIL - 정렬은
+     * 참여일(createdAt) 내림차순으로 고정
      */
     @Override
     public PageResponseDTO<ChallengeListResDTO> getMyChallengeList(Long memberId,
@@ -334,12 +329,11 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 추천 챌린지를 조회합니다.
-     * - 현재 모집 중인 챌린지 중 좋아요가 많은 순으로 조회
-     * - 페이지네이션 없이 상위 N개만 조회
+     * 추천 챌린지를 조회합니다. - 현재 모집 중인 챌린지 중 좋아요가 많은 순으로 조회 - 페이지네이션 없이 상위 N개만 조회
      */
     @Override
-    public List<ChallengeListResDTO> getRecommendedChallenges(RecommendedChallengeReqDTO requestDTO) {
+    public List<ChallengeListResDTO> getRecommendedChallenges(
+        RecommendedChallengeReqDTO requestDTO) {
         int size = requestDTO.getSize() != null ? requestDTO.getSize() : 10;
 
         List<Challenge> challenges = challengeRepository.findRecommendedChallenges(size);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -108,7 +108,12 @@ public class FeedServiceImpl implements FeedService {
         if (feedImage == null || feedImage.isEmpty()) {
             throw new IllegalArgumentException("이미지가 비어 있습니다.");
         }
-        String feedUrl = s3Service.uploadFile(UploadPath.FEED, feedImage);
+        // feed/{challengeId}/{memberId}/filename 구조로 업로드
+        String feedUrl = s3Service.uploadFile(
+            UploadPath.FEED,
+            challengeMember.getChallenge().getId() + "/" + memberId,
+            feedImage
+        );
 
         // Feed 엔티티 생성 (FeedAssembler 오버로딩 메서드 활용)
         Feed feed = FeedAssembler.toEntity(

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/controller/MemberController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/controller/MemberController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.bind.annotation.RestController;
 import site.beilsang.beilsang_server_v2.domain.member.dto.req.MemberProfileImageReqDTO;
 import site.beilsang.beilsang_server_v2.domain.member.dto.req.MemberNicknameReqDTO;
@@ -69,11 +71,11 @@ public class MemberController {
         @ApiResponse(responseCode = "400", description = "잘못된 이미지 데이터"),
         @ApiResponse(responseCode = "401", description = "인증 실패")
     })
-    @PatchMapping("/profile-image")
+    @PatchMapping(value = "/profile-image", consumes = "multipart/form-data")
     public BaseResponse<Void> updateProfileImage(Authentication authentication,
-        @Parameter(description = "프로필 이미지 수정 요청 데이터") @RequestBody MemberProfileImageReqDTO memberProfileImageReqDTO) {
+        @Parameter(description = "프로필 이미지 파일") @RequestPart("profileImage") MultipartFile profileImage) {
         Long memberId = (Long) authentication.getPrincipal();
-        memberService.updateProfileImage(memberId, memberProfileImageReqDTO);
+        memberService.updateProfileImage(memberId, new MemberProfileImageReqDTO(profileImage));
         return new BaseResponse<>();
     }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/MemberAssembler.java
@@ -8,8 +8,8 @@ import site.beilsang.beilsang_server_v2.domain.member.dto.res.CheckEnrolledResDT
 import site.beilsang.beilsang_server_v2.domain.member.dto.res.FeedCountResDTO;
 import site.beilsang.beilsang_server_v2.domain.member.dto.res.LikeCountResDTO;
 import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberLoginResDTO;
-import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberProfileImageResDTO;
 import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberNicknameResDTO;
+import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberProfileImageResDTO;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.global.enums.Provider;
 import site.beilsang.beilsang_server_v2.global.enums.Role;
@@ -29,12 +29,14 @@ public class MemberAssembler {
             .build();
     }
 
-    public static Member toEntity(Provider provider, OAuth2UserInfo oAuth2UserInfo, String nickName) {
+    public static Member toEntity(Provider provider, OAuth2UserInfo oAuth2UserInfo, String nickName,
+        String profileUrl) {
         return Member.builder()
             .provider(provider)
             .socialId(oAuth2UserInfo.getId())
             .email(oAuth2UserInfo.getEmail())
             .nickName(nickName)
+            .profileUrl(profileUrl)
             .role(Role.GUEST)
             .build();
     }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/req/MemberProfileImageReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/dto/req/MemberProfileImageReqDTO.java
@@ -1,11 +1,13 @@
 package site.beilsang.beilsang_server_v2.domain.member.dto.req;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class MemberProfileImageReqDTO {
 
     private MultipartFile profileImage;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import site.beilsang.beilsang_server_v2.domain.feed.repository.FeedRepository;
 import site.beilsang.beilsang_server_v2.domain.like.repository.ChallengeLikeRepository;
 import site.beilsang.beilsang_server_v2.domain.member.dto.MemberAssembler;
@@ -84,6 +85,13 @@ public class MemberService {
 
     public void updateProfileImage(Long memberId,
         MemberProfileImageReqDTO memberProfileImageReqDTO) {
+        MultipartFile profileImage = memberProfileImageReqDTO.getProfileImage();
+
+        // 파일 누락 또는 빈 파일이면 즉시 실패 처리 (S3 업로드 전에 검증)
+        if (profileImage == null || profileImage.isEmpty()) {
+            throw new BaseException(BaseResponseCode.INVALID_IMAGE_FILE);
+        }
+
         Member member = memberRepository.findById(memberId).
             orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
 
@@ -91,7 +99,7 @@ public class MemberService {
         String profileUrl = s3Service.uploadFile(
             UploadPath.MEMBER_PROFILE,
             memberId.toString(),
-            memberProfileImageReqDTO.getProfileImage()
+            profileImage
         );
         member.updateProfileImageUrl(profileUrl);
         memberRepository.save(member);
@@ -156,8 +164,8 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
 
-        // 이번 배포 이전에 가입한 회원은 profileUrl이 null일 수 있으므로 기본 이미지로 대체
-        if (member.getProfileUrl() == null) {
+        // 이번 배포 이전에 가입한 회원은 profileUrl이 null 또는 ""일 수 있으므로 기본 이미지로 대체
+        if (member.getProfileUrl() == null || member.getProfileUrl().isBlank()) {
             member.updateProfileImageUrl(defaultProfileImageUrl);
             memberRepository.save(member);
         }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberService.java
@@ -2,8 +2,8 @@ package site.beilsang.beilsang_server_v2.domain.member.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import site.beilsang.beilsang_server_v2.domain.feed.repository.FeedRepository;
 import site.beilsang.beilsang_server_v2.domain.like.repository.ChallengeLikeRepository;
@@ -26,12 +26,12 @@ import site.beilsang.beilsang_server_v2.domain.point.dto.res.PointLogListResDTO;
 import site.beilsang.beilsang_server_v2.domain.point.entity.PointLog;
 import site.beilsang.beilsang_server_v2.domain.point.repository.PointLogRepository;
 import site.beilsang.beilsang_server_v2.domain.point.service.PointService;
-import site.beilsang.beilsang_server_v2.domain.uuid.entity.Uuid;
-import site.beilsang.beilsang_server_v2.domain.uuid.repository.UuidRepository;
+import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
 import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
+import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 
 /**
  * 회원 관리 및 마이페이지 관련 비즈니스 로직을 처리하는 서비스 회원 프로필 관리, 포인트 내역 조회, 챌린지 참여 확인 등의 기능을 제공합니다.
@@ -46,7 +46,10 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PointLogRepository pointLogRepository;
     private final PointService pointService;
-    private final UuidRepository uuidRepository;
+    private final S3Service s3Service;
+
+    @Value("${member.default-profile-image}")
+    private String defaultProfileImageUrl;
 
     public PointLogListResDTO getPointLog(Long memberId) {
         Member member = memberRepository.findById(memberId).
@@ -79,17 +82,19 @@ public class MemberService {
         return MemberAssembler.toNicknameResDTO(member);
     }
 
-    public Void updateProfileImage(Long memberId,
+    public void updateProfileImage(Long memberId,
         MemberProfileImageReqDTO memberProfileImageReqDTO) {
         Member member = memberRepository.findById(memberId).
             orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
 
-        Uuid feedUuid = uuidRepository.save(
-            Uuid.builder().uuid(UUID.randomUUID().toString()).build());
-        //TODO - S3 설정
-//        String feedUrl = s3Manager.uploadFile(s3Manager.generateFeedKeyName(feedUuid), profileImageDTO.getProfileImage());
-//        member.updateProfileImageUrl(feedUrl);
-        return null;
+        // 회원 ID를 서브디렉토리로 사용하여 S3에 업로드 (member/profile/{memberId}/filename)
+        String profileUrl = s3Service.uploadFile(
+            UploadPath.MEMBER_PROFILE,
+            memberId.toString(),
+            memberProfileImageReqDTO.getProfileImage()
+        );
+        member.updateProfileImageUrl(profileUrl);
+        memberRepository.save(member);
     }
 
     public CheckEnrolledResDTO checkEnroll(Long memberId, Long challengeId) {
@@ -150,6 +155,13 @@ public class MemberService {
     public MemberProfileImageResDTO getProfileImage(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        // 이번 배포 이전에 가입한 회원은 profileUrl이 null일 수 있으므로 기본 이미지로 대체
+        if (member.getProfileUrl() == null) {
+            member.updateProfileImageUrl(defaultProfileImageUrl);
+            memberRepository.save(member);
+        }
+
         return MemberAssembler.toProfileImageResDTO(member);
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/service/OAuthService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/oauth/service/OAuthService.java
@@ -53,6 +53,9 @@ public class OAuthService {
     @Value("${kakao.admin-key}")
     private String kakaoAdminKey;
 
+    @Value("${member.default-profile-image}")
+    private String defaultProfileImageUrl;
+
     @Transactional
     public MemberLoginResDTO loginWithKakao(KakaoLoginReqDTO request) {
         log.info("Kakao login request received");
@@ -158,7 +161,7 @@ public class OAuthService {
                 String randomNickname = nicknameGenerator.generateRandomNickname();
                 log.info("랜덤 닉네임 생성 시도 {}/{}: {}", attempt, MAX_NICKNAME_RETRY, randomNickname);
 
-                Member newMember = MemberAssembler.toEntity(provider, attributes.getOAuth2UserInfo(), randomNickname);
+                Member newMember = MemberAssembler.toEntity(provider, attributes.getOAuth2UserInfo(), randomNickname, defaultProfileImageUrl);
                 Member savedMember = memberRepository.saveAndFlush(newMember);
 
                 // 신규 가입 보상 지급

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -37,18 +37,31 @@ public class S3Service {
     private String feedPath;
 
     public String uploadFile(UploadPath uploadPath, MultipartFile file) {
+        return uploadFile(uploadPath, null, file);
+    }
+
+    /**
+     * subDirectory를 지정하여 S3에 파일을 업로드한다.
+     * 예: uploadFile(MEMBER_PROFILE, "42", file) → member/profile/42/uuid_timestamp.ext
+     */
+    public String uploadFile(UploadPath uploadPath, String subDirectory, MultipartFile file) {
 
         if (file.isEmpty()) {
             log.info("Image is empty");
             return "";
         }
 
-        String path = switch (uploadPath) {
+        String basePath = switch (uploadPath) {
             case CHALLENGE_MAIN -> mainPath;
             case CHALLENGE_CERT -> certPath;
             case MEMBER_PROFILE -> memberProfilePath;
             case FEED -> feedPath;
         };
+
+        // subDirectory가 있으면 basePath/subDirectory/ 형태로 경로 구성
+        String path = (subDirectory != null && !subDirectory.isEmpty())
+            ? basePath + subDirectory + "/"
+            : basePath;
 
         // 파일 이름 설정
         String fileName = path + buildFileName(Objects.requireNonNull(file.getOriginalFilename()));

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -24,11 +24,8 @@ public class S3Service {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
-    @Value("${spring.cloud.aws.s3.path.challenge-main}")
-    private String mainPath;
-
-    @Value("${spring.cloud.aws.s3.path.challenge-cert}")
-    private String certPath;
+    @Value("${spring.cloud.aws.s3.path.challenge}")
+    private String challengePath;
 
     @Value("${spring.cloud.aws.s3.path.member-profile}")
     private String memberProfilePath;
@@ -52,8 +49,7 @@ public class S3Service {
         }
 
         String basePath = switch (uploadPath) {
-            case CHALLENGE_MAIN -> mainPath;
-            case CHALLENGE_CERT -> certPath;
+            case CHALLENGE -> challengePath;
             case MEMBER_PROFILE -> memberProfilePath;
             case FEED -> feedPath;
         };

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/aws/s3/S3Service.java
@@ -33,13 +33,9 @@ public class S3Service {
     @Value("${spring.cloud.aws.s3.path.feed}")
     private String feedPath;
 
-    public String uploadFile(UploadPath uploadPath, MultipartFile file) {
-        return uploadFile(uploadPath, null, file);
-    }
-
     /**
-     * subDirectory를 지정하여 S3에 파일을 업로드한다.
-     * 예: uploadFile(MEMBER_PROFILE, "42", file) → member/profile/42/uuid_timestamp.ext
+     * subDirectory를 지정하여 S3에 파일을 업로드한다. 예: uploadFile(MEMBER_PROFILE, "42", file) →
+     * member/profile/42/uuid_timestamp.ext
      */
     public String uploadFile(UploadPath uploadPath, String subDirectory, MultipartFile file) {
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/UploadPath.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/UploadPath.java
@@ -1,8 +1,7 @@
 package site.beilsang.beilsang_server_v2.global.enums;
 
 public enum UploadPath {
-    CHALLENGE_MAIN,
-    CHALLENGE_CERT,
+    CHALLENGE,
     MEMBER_PROFILE,
     FEED
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/oauth/CustomOAuth2UserService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -39,6 +40,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private final PointProperties pointProperties;
     private final NicknameGenerator nicknameGenerator;
     private static final int MAX_NICKNAME_RETRY = 5;
+
+    @Value("${member.default-profile-image}")
+    private String defaultProfileImageUrl;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -106,7 +110,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 String randomNickname = nicknameGenerator.generateRandomNickname();
                 log.info("랜덤 닉네임 생성 시도 {}/{}: {}", attempt, MAX_NICKNAME_RETRY, randomNickname);
 
-                Member newMember = MemberAssembler.toEntity(provider, attributes.getOAuth2UserInfo(), randomNickname);
+                Member newMember = MemberAssembler.toEntity(provider, attributes.getOAuth2UserInfo(), randomNickname, defaultProfileImageUrl);
                 Member savedMember = memberRepository.saveAndFlush(newMember);
 
                 log.info("회원 생성 성공 - 닉네임: {}", randomNickname);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,10 @@ point:
   reward:
     new-member: 1000  # 신규 가입 시 지급 포인트
 
+# 회원 관련 설정
+member:
+  default-profile-image: https://bs-stage-bucket.s3.ap-northeast-2.amazonaws.com/member/profile/meber-profile-default.png  # S3에 업로드된 기본 프로필 이미지 URL
+
 # Swagger/OpenAPI 설정
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ point:
 
 # 회원 관련 설정
 member:
-  default-profile-image: https://bs-stage-bucket.s3.ap-northeast-2.amazonaws.com/member/profile/meber-profile-default.png  # S3에 업로드된 기본 프로필 이미지 URL
+  default-profile-image: https://bs-stage-bucket.s3.ap-northeast-2.amazonaws.com/member/profile/member-profile-default.png  # S3에 업로드된 기본 프로필 이미지 URL (member-profile-default.png)
 
 # Swagger/OpenAPI 설정
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,8 +39,7 @@ spring:
       s3:
         bucket: bs-stage-bucket
         path:
-          challenge-main: challenge/main/
-          challenge-cert: challenge/cert/
+          challenge: challenge/
           member-profile: member/profile/
           feed: feed/
 

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,162 @@
+package site.beilsang.beilsang_server_v2.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import site.beilsang.beilsang_server_v2.domain.feed.repository.FeedRepository;
+import site.beilsang.beilsang_server_v2.domain.like.repository.ChallengeLikeRepository;
+import site.beilsang.beilsang_server_v2.domain.member.dto.req.MemberProfileImageReqDTO;
+import site.beilsang.beilsang_server_v2.domain.member.dto.res.MemberProfileImageResDTO;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMemberRepository;
+import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
+import site.beilsang.beilsang_server_v2.domain.point.repository.PointLogRepository;
+import site.beilsang.beilsang_server_v2.domain.point.service.PointService;
+import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
+import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberService 단위테스트")
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private ChallengeMemberRepository challengeMemberRepository;
+    @Mock
+    private ChallengeLikeRepository challengeLikeRepository;
+    @Mock
+    private FeedRepository feedRepository;
+    @Mock
+    private PointLogRepository pointLogRepository;
+    @Mock
+    private PointService pointService;
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private static final String DEFAULT_PROFILE_IMAGE_URL = "https://s3.example.com/member/profile/default.png";
+    private static final String UPLOADED_PROFILE_IMAGE_URL = "https://s3.example.com/member/profile/1/uuid.png";
+
+    @BeforeEach
+    void setUp() {
+        // @Value 필드 주입
+        ReflectionTestUtils.setField(memberService, "defaultProfileImageUrl", DEFAULT_PROFILE_IMAGE_URL);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업데이트 - 정상적으로 S3에 업로드되고 URL이 저장된다")
+    void updateProfileImage_success() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder().build();
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "profileImage", "profile.png", "image/png", "image-data".getBytes()
+        );
+        MemberProfileImageReqDTO reqDTO = new MemberProfileImageReqDTO(mockFile);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(s3Service.uploadFile(eq(UploadPath.MEMBER_PROFILE), eq("1"), eq(mockFile)))
+            .thenReturn(UPLOADED_PROFILE_IMAGE_URL);
+        when(memberRepository.save(any())).thenReturn(member);
+
+        // when
+        memberService.updateProfileImage(memberId, reqDTO);
+
+        // then
+        assertThat(member.getProfileUrl()).isEqualTo(UPLOADED_PROFILE_IMAGE_URL);
+        verify(s3Service).uploadFile(UploadPath.MEMBER_PROFILE, "1", mockFile);
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업데이트 - 존재하지 않는 회원이면 NOT_FOUND_MEMBER 예외가 발생한다")
+    void updateProfileImage_memberNotFound() {
+        // given
+        Long memberId = 999L;
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "profileImage", "profile.png", "image/png", "image-data".getBytes()
+        );
+        MemberProfileImageReqDTO reqDTO = new MemberProfileImageReqDTO(mockFile);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateProfileImage(memberId, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        verify(s3Service, never()).uploadFile(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 조회 - profileUrl이 있는 회원은 해당 URL을 반환한다")
+    void getProfileImage_hasProfileUrl() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder()
+            .profileUrl(UPLOADED_PROFILE_IMAGE_URL)
+            .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        MemberProfileImageResDTO result = memberService.getProfileImage(memberId);
+
+        // then
+        assertThat(result.getProfileUrl()).isEqualTo(UPLOADED_PROFILE_IMAGE_URL);
+        verify(memberRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 조회 - profileUrl이 null인 기존 회원은 기본 이미지 URL을 반환하고 저장한다")
+    void getProfileImage_nullProfileUrl_returnsDefaultImage() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder().build(); // profileUrl = null
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(memberRepository.save(any())).thenReturn(member);
+
+        // when
+        MemberProfileImageResDTO result = memberService.getProfileImage(memberId);
+
+        // then
+        assertThat(result.getProfileUrl()).isEqualTo(DEFAULT_PROFILE_IMAGE_URL);
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 조회 - 존재하지 않는 회원이면 NOT_FOUND_MEMBER 예외가 발생한다")
+    void getProfileImage_memberNotFound() {
+        // given
+        Long memberId = 999L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getProfileImage(memberId))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.NOT_FOUND_MEMBER));
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호

- #106

## 🍬 기능 설명

- 회원가입 시 S3 기본 프로필 이미지 URL을 자동으로 설정
- `PATCH /api/profile-image` — multipart/form-data로 프로필 이미지를 업로드하여 S3에 저장하고 URL을 갱신
- `GET /api/profile-image` — 프로필 이미지 URL 조회 (기존 회원 중 profileUrl이 null인 경우 기본 이미지로 자동 설정)
- S3 업로드 경로를 도메인 > ID > 타입 순으로 계층화하여 관리
  - `challenge/{challengeId}/main|cert/filename`
  - `feed/{challengeId}/{memberId}/filename`
  - `member/profile/{memberId}/filename`
- `UploadPath` enum에서 `CHALLENGE_MAIN`/`CHALLENGE_CERT`를 `CHALLENGE`로 통합

## 🤔 코드 리뷰에서 집중적으로 볼 내용

**기존 회원 null profileUrl 처리 방식**

이번 배포 이전에 가입한 회원은 `profileUrl`이 null입니다.
`getProfileImage()` 호출 시점에 기본 이미지를 저장하는 방식으로 처리했는데, 배치로 일괄 마이그레이션하는 방법도 고려할 수 있습니다.

```java
if (member.getProfileUrl() == null) {
    member.updateProfileImageUrl(defaultProfileImageUrl);
    memberRepository.save(member);
}
```

## ⭐ 기타 사항

- 기본 프로필 이미지는 S3에 미리 업로드해두고 URL을 관리합니다.
- 로컬/스테이지/프로덕션 환경 구분 없이 동일한 S3 URL을 사용합니다.