### PR TITLE
[Feat] 신고 기능 구현

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/achivement/service/AchievementServiceImpl.java
@@ -33,9 +33,9 @@ public class AchievementServiceImpl implements AchievementService {
     public HallOfFameListResDto getCategoryHallOfFame(Category category) {
         List<Challenge> topChallenges;
         if (category == Category.ALL) {
-            topChallenges = challengeRepository.findTop10ByOrderByCountLikesDescStartDateDesc();
+            topChallenges = challengeRepository.findTop10ByIsHiddenFalseOrderByCountLikesDescStartDateDesc();
         } else {
-            topChallenges = challengeRepository.findTop10ByCategoryOrderByCountLikesDescStartDateDesc(
+            topChallenges = challengeRepository.findTop10ByCategoryAndIsHiddenFalseOrderByCountLikesDescStartDateDesc(
                 category);
         }
 
@@ -61,7 +61,7 @@ public class AchievementServiceImpl implements AchievementService {
         if (category == Category.ALL) {
             feedsPage = feedRepository.findAll(pageable);
         } else {
-            feedsPage = feedRepository.findAllByChallenge_Category(category, pageable);
+            feedsPage = feedRepository.findAllByChallenge_CategoryAndIsHiddenFalse(category, pageable);
         }
         return FeedAssembler.toSliceResponseDTO(feedsPage, memberId);
     }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/entity/Challenge.java
@@ -93,6 +93,14 @@ public class Challenge extends BaseEntity {
     @Builder.Default
     private Boolean isSettled = false;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer reportCount = 0;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isHidden = false;
+
     public void updateStatus(ChallengeStatus status) {
         this.status = status;
     }
@@ -135,5 +143,13 @@ public class Challenge extends BaseEntity {
         if (this.countLikes > 0) {
             this.countLikes--;
         }
+    }
+
+    public void incrementReportCount() {
+        this.reportCount++;
+    }
+
+    public void hide() {
+        this.isHidden = true;
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepository.java
@@ -9,9 +9,12 @@ import java.util.List;
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>,
     ChallengeRepositoryCustom {
 
-    Challenge getChallengeById(Long id);
+    // 숨김 처리된 챌린지 제외
+    Challenge getChallengeByIdAndIsHiddenFalse(Long id);
 
-    List<Challenge> findTop10ByOrderByCountLikesDescStartDateDesc();
+    // 숨김 처리된 챌린지 제외
+    List<Challenge> findTop10ByIsHiddenFalseOrderByCountLikesDescStartDateDesc();
 
-    List<Challenge> findTop10ByCategoryOrderByCountLikesDescStartDateDesc(Category category);
+    // 숨김 처리된 챌린지 제외
+    List<Challenge> findTop10ByCategoryAndIsHiddenFalseOrderByCountLikesDescStartDateDesc(Category category);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -36,6 +36,7 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         BooleanBuilder builder = new BooleanBuilder();
 
         // 필터링 조건 추가
+        addHiddenFilter(builder, challenge);
         addCategoryFilter(builder, challenge, requestDTO);
         addKeywordFilter(builder, challenge, requestDTO);
         addChallengeStatusFilter(builder, challenge, requestDTO);
@@ -53,6 +54,13 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         long total = countTotal(challenge, builder);
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 숨김 처리된 챌린지 제외 필터 추가
+     */
+    private void addHiddenFilter(BooleanBuilder builder, QChallenge challenge) {
+        builder.and(challenge.isHidden.isFalse());
     }
 
     private void addCategoryFilter(BooleanBuilder builder, QChallenge challenge,
@@ -150,6 +158,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         // 모집중 조건: 시작일이 오늘 이후 (오늘 포함)
         builder.and(challenge.startDate.goe(LocalDate.now()));
 
+        // 숨김 처리된 챌린지 제외
+        addHiddenFilter(builder, challenge);
+
         // 카테고리 필터 (ALL이 아닌 경우에만 필터링)
         if (requestDTO.getCategory() != Category.ALL) {
             builder.and(challenge.category.eq(requestDTO.getCategory()));
@@ -193,6 +204,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         // 모집마감 조건: 시작일이 오늘 이전
         builder.and(challenge.startDate.lt(LocalDate.now()));
 
+        // 숨김 처리된 챌린지 제외
+        addHiddenFilter(builder, challenge);
+
         // 카테고리 필터 (ALL이 아닌 경우에만 필터링)
         if (requestDTO.getCategory() != Category.ALL) {
             builder.and(challenge.category.eq(requestDTO.getCategory()));
@@ -228,6 +242,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
         if (requestDTO.getCategory() != Category.ALL) {
             builder.and(challenge.category.eq(requestDTO.getCategory()));
         }
+
+        // 숨김 처리된 챌린지 제외
+        addHiddenFilter(builder, challenge);
 
         // 쿼리 생성 - ChallengeLike 조인
         JPAQuery<Challenge> query = queryFactory
@@ -280,6 +297,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
             builder.and(challenge.category.eq(requestDTO.getCategory()));
         }
 
+        // 숨김 처리된 챌린지 제외
+        addHiddenFilter(builder, challenge);
+
         // 참여 상태 필터
         BooleanBuilder statusBuilder = new BooleanBuilder();
         ParticipationStatus status = requestDTO.getParticipationStatus();
@@ -329,7 +349,8 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
 
         return queryFactory
             .selectFrom(challenge)
-            .where(challenge.startDate.goe(LocalDate.now()))  // 모집 중 조건
+            .where(challenge.startDate.goe(LocalDate.now())  // 모집 중 조건
+                .and(challenge.isHidden.isFalse()))           // 숨김 처리된 챌린지 제외
             .orderBy(challenge.countLikes.desc(), challenge.startDate.asc())  // 좋아요 내림차순, 시작일 오름차순
             .limit(size)
             .fetch();
@@ -347,6 +368,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
 
         // 모집 마감 조건: 시작일이 오늘 이전
         builder.and(challenge.startDate.lt(LocalDate.now()));
+
+        // 숨김 처리된 챌린지 제외
+        addHiddenFilter(builder, challenge);
 
         // 제목 키워드 필터
         addTitleKeywordFilter(builder, challenge, keyword);
@@ -378,6 +402,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
 
         // 모집 중 조건: 시작일이 오늘 이후 (오늘 포함)
         builder.and(challenge.startDate.goe(LocalDate.now()));
+
+        // 숨김 처리된 챌린지 제외
+        addHiddenFilter(builder, challenge);
 
         // 제목 키워드 필터
         addTitleKeywordFilter(builder, challenge, keyword);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -345,7 +345,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public ChallengeDetailResDTO getChallengeDetail(Long challengeId, Long memberId) {
-        Challenge challenge = challengeRepository.getChallengeById(challengeId);
+        Challenge challenge = challengeRepository.getChallengeByIdAndIsHiddenFalse(challengeId);
         if (challenge == null) {
             throw new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE);
         }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/entity/Feed.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/entity/Feed.java
@@ -52,4 +52,20 @@ public class Feed extends BaseEntity {
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<FeedLike> feedLikes = new ArrayList<>();
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer reportCount = 0;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isHidden = false;
+
+    public void incrementReportCount() {
+        this.reportCount++;
+    }
+
+    public void hide() {
+        this.isHidden = true;
+    }
+
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
@@ -54,4 +55,13 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
      */
     Slice<Feed> findAllByChallenge_IdAndChallengeMember_Member_IdOrderByCreatedAtDesc(
         Long challengeId, Long memberId, Pageable pageable);
+
+    /**
+     * 챌린지 숨김 처리 시 해당 챌린지의 모든 피드를 일괄 숨김 처리
+     *
+     * @param challengeId 챌린지 ID
+     */
+    @Modifying
+    @Query("UPDATE Feed f SET f.isHidden = true WHERE f.challenge.id = :challengeId")
+    void hideAllByChallengeId(@Param("challengeId") Long challengeId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepository.java
@@ -17,43 +17,46 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
 
     List<Feed> findTop4ByChallengeMember_IdInOrderByCreatedAtDesc(List<Long> challengeMemberIds);
 
-    Slice<Feed> findAllByChallenge_Category(Category category, Pageable pageable);
+    // isHidden = false 조건 추가 — 숨김 처리된 피드 제외
+    Slice<Feed> findAllByChallenge_CategoryAndIsHiddenFalse(Category category, Pageable pageable);
 
-    Slice<Feed> findAllByChallengeMember_Member_IdOrderByCreatedAtDesc(Long memberId,
-                                                                       Pageable pageable);
+    // isHidden = false 조건 추가 — 숨김 처리된 피드 제외
+    Slice<Feed> findAllByChallengeMember_Member_IdAndIsHiddenFalseOrderByCreatedAtDesc(
+        Long memberId, Pageable pageable);
 
     /**
-     * 특정 사용자의 피드 중 특정 카테고리에 속한 피드를 최신순으로 조회
+     * 특정 사용자의 피드 중 특정 카테고리에 속한 피드를 최신순으로 조회 (숨김 제외)
      *
      * @param memberId 사용자 ID
      * @param category 챌린지 카테고리
      * @param pageable 페이징 정보
      * @return 조회된 피드 목록 (Slice)
      */
-    Slice<Feed> findAllByChallengeMember_Member_IdAndChallenge_CategoryOrderByCreatedAtDesc(
+    Slice<Feed> findAllByChallengeMember_Member_IdAndChallenge_CategoryAndIsHiddenFalseOrderByCreatedAtDesc(
         Long memberId, Category category, Pageable pageable);
 
     @Query("SELECT COUNT(f) FROM Feed f WHERE f.challengeMember.member.id = :memberId")
     Long countByMemberId(@Param("memberId") Long memberId);
 
     /**
-     * 특정 챌린지의 전체 피드를 최신순으로 조회
+     * 특정 챌린지의 전체 피드를 최신순으로 조회 (숨김 제외)
      *
      * @param challengeId 챌린지 ID
      * @param pageable    페이징 정보
      * @return 조회된 피드 목록 (Slice)
      */
-    Slice<Feed> findAllByChallenge_IdOrderByCreatedAtDesc(Long challengeId, Pageable pageable);
+    Slice<Feed> findAllByChallenge_IdAndIsHiddenFalseOrderByCreatedAtDesc(Long challengeId,
+        Pageable pageable);
 
     /**
-     * 특정 챌린지에서 특정 멤버가 작성한 피드를 최신순으로 조회 (인증 피드 조회용)
+     * 특정 챌린지에서 특정 멤버가 작성한 피드를 최신순으로 조회 (인증 피드 조회용, 숨김 제외)
      *
      * @param challengeId 챌린지 ID
      * @param memberId    사용자 ID
      * @param pageable    페이징 정보
      * @return 조회된 피드 목록 (Slice)
      */
-    Slice<Feed> findAllByChallenge_IdAndChallengeMember_Member_IdOrderByCreatedAtDesc(
+    Slice<Feed> findAllByChallenge_IdAndChallengeMember_Member_IdAndIsHiddenFalseOrderByCreatedAtDesc(
         Long challengeId, Long memberId, Pageable pageable);
 
     /**
@@ -61,7 +64,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
      *
      * @param challengeId 챌린지 ID
      */
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Feed f SET f.isHidden = true WHERE f.challenge.id = :challengeId")
     void hideAllByChallengeId(@Param("challengeId") Long challengeId);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/repository/FeedRepositoryImpl.java
@@ -38,6 +38,9 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         // 키워드 필터링 (review 필드 검색)
         addKeywordFilter(builder, feed, keyword);
 
+        // 숨김 처리된 피드 제외
+        builder.and(feed.isHidden.isFalse());
+
         // 쿼리 생성
         JPAQuery<Feed> query = queryFactory
             .selectFrom(feed)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -54,12 +54,12 @@ public class FeedServiceImpl implements FeedService {
 
         Slice<Feed> feedSlice;
         if (requestDTO.getCategory() == Category.ALL) {
-            // 전체 조회
+            // 전체 조회 (숨김 제외)
             feedSlice = feedRepository.findAll(pageable);
         } else {
-            // 카테고리별 조회
-            feedSlice = feedRepository.findAllByChallenge_Category(requestDTO.getCategory(),
-                pageable);
+            // 카테고리별 조회 (숨김 제외)
+            feedSlice = feedRepository.findAllByChallenge_CategoryAndIsHiddenFalse(
+                requestDTO.getCategory(), pageable);
         }
 
         // SliceResponseDTO로 변환
@@ -204,11 +204,12 @@ public class FeedServiceImpl implements FeedService {
 
         // 카테고리 필터링 처리
         if (category == Category.ALL) {
-            feedSlice = feedRepository.findAllByChallengeMember_Member_IdOrderByCreatedAtDesc(
+            // 전체 조회 (숨김 제외)
+            feedSlice = feedRepository.findAllByChallengeMember_Member_IdAndIsHiddenFalseOrderByCreatedAtDesc(
                 memberId, pageable);
         } else {
-            // 특정 카테고리의 피드만 조회
-            feedSlice = feedRepository.findAllByChallengeMember_Member_IdAndChallenge_CategoryOrderByCreatedAtDesc(
+            // 특정 카테고리의 피드만 조회 (숨김 제외)
+            feedSlice = feedRepository.findAllByChallengeMember_Member_IdAndChallenge_CategoryAndIsHiddenFalseOrderByCreatedAtDesc(
                 memberId, category, pageable);
         }
 
@@ -231,9 +232,9 @@ public class FeedServiceImpl implements FeedService {
         // 최신순 페이징 처리
         Pageable pageable = PageRequest.of(page, size);
 
-        // 챌린지 ID + 멤버 ID 기준 피드 조회
+        // 챌린지 ID + 멤버 ID 기준 피드 조회 (숨김 제외)
         Slice<Feed> feedSlice =
-            feedRepository.findAllByChallenge_IdAndChallengeMember_Member_IdOrderByCreatedAtDesc(
+            feedRepository.findAllByChallenge_IdAndChallengeMember_Member_IdAndIsHiddenFalseOrderByCreatedAtDesc(
                 challengeId, memberId, pageable);
 
         return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);
@@ -250,8 +251,8 @@ public class FeedServiceImpl implements FeedService {
         // 최신순 페이징 처리
         Pageable pageable = PageRequest.of(page, size);
 
-        // 챌린지 ID 기준 피드 조회
-        Slice<Feed> feedSlice = feedRepository.findAllByChallenge_IdOrderByCreatedAtDesc(
+        // 챌린지 ID 기준 피드 조회 (숨김 제외)
+        Slice<Feed> feedSlice = feedRepository.findAllByChallenge_IdAndIsHiddenFalseOrderByCreatedAtDesc(
             challengeId, pageable);
 
         return FeedAssembler.toSliceResponseDTO(feedSlice, memberId);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/controller/ReportController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/controller/ReportController.java
@@ -1,0 +1,60 @@
+package site.beilsang.beilsang_server_v2.domain.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import site.beilsang.beilsang_server_v2.domain.report.dto.ChallengeReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.dto.FeedReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.service.ReportService;
+import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Report", description = "신고 API")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "피드 신고", description = "인증 피드를 신고합니다. 누적 3회 도달 시 자동으로 숨김 처리됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "피드 신고 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 신고한 피드 / 이미 숨김 처리된 피드 / 기타 사유 미입력"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "피드를 찾을 수 없음")
+    })
+    @PostMapping("/feed/{feedId}/report")
+    public BaseResponse<Void> reportFeed(
+        @Parameter(description = "신고할 피드 ID", example = "1") @PathVariable Long feedId,
+        @Valid @RequestBody FeedReportReqDTO reqDTO,
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        reportService.reportFeed(memberId, feedId, reqDTO);
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "챌린지 신고", description = "챌린지를 신고합니다. 누적 3회 도달 시 챌린지 및 해당 챌린지의 모든 피드가 자동으로 숨김 처리됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "챌린지 신고 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 신고한 챌린지 / 이미 숨김 처리된 챌린지 / 기타 사유 미입력"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음")
+    })
+    @PostMapping("/challenge/{challengeId}/report")
+    public BaseResponse<Void> reportChallenge(
+        @Parameter(description = "신고할 챌린지 ID", example = "1") @PathVariable Long challengeId,
+        @Valid @RequestBody ChallengeReportReqDTO reqDTO,
+        Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        reportService.reportChallenge(memberId, challengeId, reqDTO);
+        return new BaseResponse<>();
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/dto/ChallengeReportReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/dto/ChallengeReportReqDTO.java
@@ -1,0 +1,28 @@
+package site.beilsang.beilsang_server_v2.domain.report.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeReportReason;
+
+@Schema(description = "챌린지 신고 요청 DTO")
+@Getter
+@Setter
+public class ChallengeReportReqDTO {
+
+    @Schema(
+        description = "신고 사유",
+        example = "SPAM",
+        allowableValues = {"UNRELATED", "SPAM", "INAPPROPRIATE", "ILLEGAL", "ETC"},
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull(message = "신고 사유는 필수입니다.")
+    private ChallengeReportReason reason;
+
+    @Schema(
+        description = "기타 신고 사유 직접 입력 (reason이 ETC인 경우 필수)",
+        example = "기타 신고 사유입니다."
+    )
+    private String detail;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/dto/FeedReportReqDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/dto/FeedReportReqDTO.java
@@ -1,0 +1,28 @@
+package site.beilsang.beilsang_server_v2.domain.report.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import site.beilsang.beilsang_server_v2.global.enums.FeedReportReason;
+
+@Schema(description = "피드 신고 요청 DTO")
+@Getter
+@Setter
+public class FeedReportReqDTO {
+
+    @Schema(
+        description = "신고 사유",
+        example = "SPAM",
+        allowableValues = {"UNRELATED", "FALSE_CERT", "SPAM", "INAPPROPRIATE", "ETC"},
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull(message = "신고 사유는 필수입니다.")
+    private FeedReportReason reason;
+
+    @Schema(
+        description = "기타 신고 사유 직접 입력 (reason이 ETC인 경우 필수)",
+        example = "기타 신고 사유입니다."
+    )
+    private String detail;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/entity/Report.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/entity/Report.java
@@ -1,0 +1,74 @@
+package site.beilsang.beilsang_server_v2.domain.report.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.global.common.BaseEntity;
+import site.beilsang.beilsang_server_v2.global.enums.ReportStatus;
+import site.beilsang.beilsang_server_v2.global.enums.ReportType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+    uniqueConstraints = {
+        // 한 회원이 같은 피드를 중복 신고할 수 없음
+        @UniqueConstraint(columnNames = {"member_id", "feed_id"}),
+        // 한 회원이 같은 챌린지를 중복 신고할 수 없음
+        @UniqueConstraint(columnNames = {"member_id", "challenge_id"})
+    }
+)
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportType reportType;
+
+    // 신고 사유 코드 (FeedReportReason 또는 ChallengeReportReason의 name())
+    @Column(nullable = false)
+    private String reason;
+
+    // 기타(ETC) 사유 직접 입력
+    @Column(columnDefinition = "TEXT")
+    private String detail;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(nullable = false)
+    private ReportStatus status = ReportStatus.RECEIVED;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/entity/Report.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/entity/Report.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
@@ -71,4 +72,14 @@ public class Report extends BaseEntity {
     @Builder.Default
     @Column(nullable = false)
     private ReportStatus status = ReportStatus.RECEIVED;
+
+    /**
+     * 저장 전 검증: feed와 challenge 중 정확히 하나만 설정되어야 한다.
+     */
+    @PrePersist
+    private void validateTarget() {
+        if ((feed == null) == (challenge == null)) {
+            throw new IllegalStateException("신고 대상은 피드 또는 챌린지 중 하나만 지정해야 합니다.");
+        }
+    }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/repository/ReportRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/repository/ReportRepository.java
@@ -1,0 +1,25 @@
+package site.beilsang.beilsang_server_v2.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.beilsang.beilsang_server_v2.domain.report.entity.Report;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    /**
+     * 특정 회원이 특정 피드를 이미 신고했는지 확인 (중복 신고 방지)
+     *
+     * @param memberId 회원 ID
+     * @param feedId   피드 ID
+     * @return 신고 여부
+     */
+    boolean existsByMemberIdAndFeedId(Long memberId, Long feedId);
+
+    /**
+     * 특정 회원이 특정 챌린지를 이미 신고했는지 확인 (중복 신고 방지)
+     *
+     * @param memberId    회원 ID
+     * @param challengeId 챌린지 ID
+     * @return 신고 여부
+     */
+    boolean existsByMemberIdAndChallengeId(Long memberId, Long challengeId);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/service/ReportService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/service/ReportService.java
@@ -1,0 +1,25 @@
+package site.beilsang.beilsang_server_v2.domain.report.service;
+
+import site.beilsang.beilsang_server_v2.domain.report.dto.ChallengeReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.dto.FeedReportReqDTO;
+
+public interface ReportService {
+
+    /**
+     * 피드 신고 처리
+     *
+     * @param memberId 신고한 회원 ID
+     * @param feedId   신고 대상 피드 ID
+     * @param reqDTO   신고 요청 정보 (사유, 상세)
+     */
+    void reportFeed(Long memberId, Long feedId, FeedReportReqDTO reqDTO);
+
+    /**
+     * 챌린지 신고 처리
+     *
+     * @param memberId    신고한 회원 ID
+     * @param challengeId 신고 대상 챌린지 ID
+     * @param reqDTO      신고 요청 정보 (사유, 상세)
+     */
+    void reportChallenge(Long memberId, Long challengeId, ChallengeReportReqDTO reqDTO);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/report/service/ReportServiceImpl.java
@@ -1,0 +1,122 @@
+package site.beilsang.beilsang_server_v2.domain.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
+import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
+import site.beilsang.beilsang_server_v2.domain.feed.repository.FeedRepository;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
+import site.beilsang.beilsang_server_v2.domain.report.dto.ChallengeReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.dto.FeedReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.entity.Report;
+import site.beilsang.beilsang_server_v2.domain.report.repository.ReportRepository;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
+import site.beilsang.beilsang_server_v2.global.enums.FeedReportReason;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeReportReason;
+import site.beilsang.beilsang_server_v2.global.enums.ReportType;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportServiceImpl implements ReportService {
+
+    // 누적 신고 임계치 — 이 값에 도달하면 즉시 숨김 처리
+    private static final int REPORT_THRESHOLD = 3;
+
+    private final ReportRepository reportRepository;
+    private final FeedRepository feedRepository;
+    private final ChallengeRepository challengeRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void reportFeed(Long memberId, Long feedId, FeedReportReqDTO reqDTO) {
+        // 기타 사유 선택 시 상세 내용 필수
+        validateDetail(reqDTO.getReason() == FeedReportReason.ETC, reqDTO.getDetail());
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        Feed feed = feedRepository.findById(feedId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_FEED));
+
+        // 이미 숨김 처리된 피드인지 확인
+        if (feed.getIsHidden()) {
+            throw new BaseException(BaseResponseCode.ALREADY_HIDDEN_FEED);
+        }
+
+        // 중복 신고 확인
+        if (reportRepository.existsByMemberIdAndFeedId(memberId, feedId)) {
+            throw new BaseException(BaseResponseCode.ALREADY_REPORTED);
+        }
+
+        // 신고 레코드 저장
+        reportRepository.save(Report.builder()
+            .member(member)
+            .feed(feed)
+            .reportType(ReportType.FEED)
+            .reason(reqDTO.getReason().name())
+            .detail(reqDTO.getDetail())
+            .build());
+
+        // 신고 수 증가 및 임계치 도달 시 숨김 처리
+        feed.incrementReportCount();
+        if (feed.getReportCount() >= REPORT_THRESHOLD) {
+            feed.hide();
+        }
+    }
+
+    @Override
+    public void reportChallenge(Long memberId, Long challengeId, ChallengeReportReqDTO reqDTO) {
+        // 기타 사유 선택 시 상세 내용 필수
+        validateDetail(reqDTO.getReason() == ChallengeReportReason.ETC, reqDTO.getDetail());
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_MEMBER));
+
+        Challenge challenge = challengeRepository.findById(challengeId)
+            .orElseThrow(() -> new BaseException(BaseResponseCode.NOT_FOUND_CHALLENGE));
+
+        // 이미 숨김 처리된 챌린지인지 확인
+        if (challenge.getIsHidden()) {
+            throw new BaseException(BaseResponseCode.ALREADY_HIDDEN_CHALLENGE);
+        }
+
+        // 중복 신고 확인
+        if (reportRepository.existsByMemberIdAndChallengeId(memberId, challengeId)) {
+            throw new BaseException(BaseResponseCode.ALREADY_REPORTED);
+        }
+
+        // 신고 레코드 저장
+        reportRepository.save(Report.builder()
+            .member(member)
+            .challenge(challenge)
+            .reportType(ReportType.CHALLENGE)
+            .reason(reqDTO.getReason().name())
+            .detail(reqDTO.getDetail())
+            .build());
+
+        // 신고 수 증가 및 임계치 도달 시 챌린지·피드 일괄 숨김 처리
+        challenge.incrementReportCount();
+        if (challenge.getReportCount() >= REPORT_THRESHOLD) {
+            challenge.hide();
+            // 해당 챌린지의 모든 피드도 연쇄 숨김 처리
+            feedRepository.hideAllByChallengeId(challengeId);
+        }
+    }
+
+    /**
+     * ETC 사유 선택 시 detail 필드 입력 여부 검증
+     *
+     * @param isEtc   기타 사유 선택 여부
+     * @param detail  상세 사유
+     */
+    private void validateDetail(boolean isEtc, String detail) {
+        if (isEtc && (detail == null || detail.isBlank())) {
+            throw new BaseException(BaseResponseCode.MISSING_REPORT_DETAIL);
+        }
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -41,6 +41,9 @@ public enum BaseResponseCode {
     // point
     NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "P0001", "포인트가 부족합니다."),
 
+    // feed
+    NOT_FOUND_FEED(HttpStatus.BAD_REQUEST, "F0001", "존재하지 않는 피드입니다"),
+
     // challenge
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "C0001", "유효하지 않은 이미지 파일입니다"),
     INVALID_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "C0002", "목표 실천일수가 챌린지 기간을 초과할 수 없습니다"),
@@ -52,7 +55,13 @@ public enum BaseResponseCode {
     NOT_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0008", "찜하지 않은 챌린지입니다"),
     NOT_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0009", "참여하지 않은 챌린지입니다"),
     CHALLENGE_NOT_ENDED(HttpStatus.BAD_REQUEST, "C0010", "완료되지 않은 챌린지입니다"),
-    CHALLENGE_NOT_STARTED(HttpStatus.BAD_REQUEST, "C0011", "아직 시작하지 않은 챌린지입니다");
+    CHALLENGE_NOT_STARTED(HttpStatus.BAD_REQUEST, "C0011", "아직 시작하지 않은 챌린지입니다"),
+
+    // report
+    ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "R0001", "이미 신고한 피드/챌린지입니다"),
+    ALREADY_HIDDEN_FEED(HttpStatus.BAD_REQUEST, "R0002", "이미 숨김 처리된 피드입니다"),
+    ALREADY_HIDDEN_CHALLENGE(HttpStatus.BAD_REQUEST, "R0003", "이미 숨김 처리된 챌린지입니다"),
+    MISSING_REPORT_DETAIL(HttpStatus.BAD_REQUEST, "R0004", "기타 신고 사유를 입력해주세요");
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeReportReason.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeReportReason.java
@@ -1,0 +1,9 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum ChallengeReportReason {
+    UNRELATED,    // 친환경 챌린지 목적과 무관함
+    SPAM,         // 스팸 / 광고 / 홍보성 챌린지
+    INAPPROPRIATE, // 욕설·혐오·선정적 등 부적절한 내용 포함
+    ILLEGAL,      // 위험하거나 불법적인 행위를 유도함
+    ETC           // 기타 (직접 입력)
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/FeedReportReason.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/FeedReportReason.java
@@ -1,0 +1,9 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum FeedReportReason {
+    UNRELATED,    // 친환경 챌린지 목적과 무관함
+    FALSE_CERT,   // 허위 또는 조작(AI)된 이미지
+    SPAM,         // 스팸 / 광고 / 홍보성 게시물
+    INAPPROPRIATE, // 선정적·폭력적이거나 불쾌감을 주는 이미지
+    ETC           // 기타 (직접 입력)
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ReportStatus.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ReportStatus.java
@@ -1,0 +1,7 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum ReportStatus {
+    RECEIVED,   // 접수
+    REVIEWED,   // 검토 완료
+    DISMISSED   // 반려
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ReportType.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ReportType.java
@@ -1,0 +1,6 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+public enum ReportType {
+    FEED,
+    CHALLENGE
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: beilsang-server-v2
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local-postgre} # 배포시 github actions에서 환경변수로 stage/prod 설정
+    active: ${SPRING_PROFILES_ACTIVE:local-mysql} # 배포시 github actions에서 환경변수로 stage/prod 설정
   config:
     import:
       - classpath:nickname.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: beilsang-server-v2
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local-mysql} # 배포시 github actions에서 환경변수로 stage/prod 설정
+    active: ${SPRING_PROFILES_ACTIVE:local-postgre} # 배포시 github actions에서 환경변수로 stage/prod 설정
   config:
     import:
       - classpath:nickname.yml

--- a/src/test/java/site/beilsang/beilsang_server_v2/BeilsangServerV2ApplicationTests.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/BeilsangServerV2ApplicationTests.java
@@ -1,12 +1,11 @@
 package site.beilsang.beilsang_server_v2;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.boot.test.context.SpringBootTest;
 
-// AWS, Apple OAuth 등 외부 환경변수가 필요한 통합 테스트
-// CI/CD 파이프라인에서 실제 환경변수 주입 후 실행
-@Disabled("외부 환경변수(AWS, Apple OAuth 등) 없이는 실행 불가 — CI/CD 환경에서만 실행")
+// AWS, Apple OAuth 등 외부 환경변수가 모두 주입된 환경(CI/CD)에서만 실행
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".+")
 @SpringBootTest
 class BeilsangServerV2ApplicationTests {
 

--- a/src/test/java/site/beilsang/beilsang_server_v2/BeilsangServerV2ApplicationTests.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/BeilsangServerV2ApplicationTests.java
@@ -1,8 +1,12 @@
 package site.beilsang.beilsang_server_v2;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+// AWS, Apple OAuth 등 외부 환경변수가 필요한 통합 테스트
+// CI/CD 파이프라인에서 실제 환경변수 주입 후 실행
+@Disabled("외부 환경변수(AWS, Apple OAuth 등) 없이는 실행 불가 — CI/CD 환경에서만 실행")
 @SpringBootTest
 class BeilsangServerV2ApplicationTests {
 

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -72,6 +72,9 @@ class ChallengeServiceImplTest {
     @Mock
     private site.beilsang.beilsang_server_v2.domain.point.service.PointService pointService;
 
+    @Mock
+    private site.beilsang.beilsang_server_v2.domain.like.repository.ChallengeLikeRepository challengeLikeRepository;
+
 
     @InjectMocks
     private ChallengeServiceImpl challengeService;
@@ -227,7 +230,7 @@ class ChallengeServiceImplTest {
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(
             mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
-        when(s3Service.uploadFile(any(UploadPath.class), any(MultipartFile.class)))
+        when(s3Service.uploadFile(any(UploadPath.class), any(String.class), any(MultipartFile.class)))
             .thenReturn("https://s3-url/test.jpg");
 
         // when
@@ -243,7 +246,7 @@ class ChallengeServiceImplTest {
         assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(
             ChallengeMemberStatus.NOT_YET);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class),
-            any(MultipartFile.class));
+            any(String.class), any(MultipartFile.class));
     }
 
     @Test
@@ -261,7 +264,7 @@ class ChallengeServiceImplTest {
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(
             mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
-        when(s3Service.uploadFile(any(UploadPath.class), any(MultipartFile.class)))
+        when(s3Service.uploadFile(any(UploadPath.class), any(String.class), any(MultipartFile.class)))
             .thenReturn("https://s3-url/test.jpg");
 
         // when
@@ -277,7 +280,7 @@ class ChallengeServiceImplTest {
         assertThat(savedChallengeMember.getChallengeMemberStatus()).isEqualTo(
             ChallengeMemberStatus.ONGOING);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class),
-            any(MultipartFile.class));
+            any(String.class), any(MultipartFile.class));
     }
 
     @Test
@@ -300,7 +303,7 @@ class ChallengeServiceImplTest {
         when(challengeMemberRepository.save(any(ChallengeMember.class))).thenReturn(
             mock(ChallengeMember.class));
         when(pointLogRepository.save(any(PointLog.class))).thenReturn(mock(PointLog.class));
-        when(s3Service.uploadFile(any(UploadPath.class), any(MultipartFile.class)))
+        when(s3Service.uploadFile(any(UploadPath.class), any(String.class), any(MultipartFile.class)))
             .thenReturn("https://s3-url/test.jpg");
 
         // when
@@ -311,7 +314,7 @@ class ChallengeServiceImplTest {
         // then
         assertThat(memberWithPoint.getPoint()).isEqualTo(initialPoint - joinPoint);
         verify(s3Service, atLeastOnce()).uploadFile(any(UploadPath.class),
-            any(MultipartFile.class));
+            any(String.class), any(MultipartFile.class));
     }
 
     @Test
@@ -324,6 +327,8 @@ class ChallengeServiceImplTest {
         when(challengeRepository.getChallengeById(challengeId)).thenReturn(challenge_ONGOING);
         when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId,
             memberId)).thenReturn(Optional.empty());
+        when(challengeMemberRepository.findByChallengeIdAndIsHost(challengeId, true))
+            .thenReturn(Optional.empty());
 
         // when
         var result = challengeService.getChallengeDetail(challengeId, memberId);

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImplTest.java
@@ -324,7 +324,7 @@ class ChallengeServiceImplTest {
         Long memberId = 2L; // 테스트 멤버(참여하지 않은 사용자)
         Long challengeId = 1L;
 
-        when(challengeRepository.getChallengeById(challengeId)).thenReturn(challenge_ONGOING);
+        when(challengeRepository.getChallengeByIdAndIsHiddenFalse(challengeId)).thenReturn(challenge_ONGOING);
         when(challengeMemberRepository.findByChallengeIdAndMemberId(challengeId,
             memberId)).thenReturn(Optional.empty());
         when(challengeMemberRepository.findByChallengeIdAndIsHost(challengeId, true))

--- a/src/test/java/site/beilsang/beilsang_server_v2/domain/report/service/ReportServiceImplTest.java
+++ b/src/test/java/site/beilsang/beilsang_server_v2/domain/report/service/ReportServiceImplTest.java
@@ -1,0 +1,303 @@
+package site.beilsang.beilsang_server_v2.domain.report.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
+import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
+import site.beilsang.beilsang_server_v2.domain.feed.entity.Feed;
+import site.beilsang.beilsang_server_v2.domain.feed.repository.FeedRepository;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
+import site.beilsang.beilsang_server_v2.domain.report.dto.ChallengeReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.dto.FeedReportReqDTO;
+import site.beilsang.beilsang_server_v2.domain.report.entity.Report;
+import site.beilsang.beilsang_server_v2.domain.report.repository.ReportRepository;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeReportReason;
+import site.beilsang.beilsang_server_v2.global.enums.FeedReportReason;
+import site.beilsang.beilsang_server_v2.global.enums.ReportType;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReportService 단위테스트")
+class ReportServiceImplTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private ReportServiceImpl reportService;
+
+    private Member testMember;
+    private Feed testFeed;
+    private Challenge testChallenge;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+            .build();
+
+        testFeed = Feed.builder()
+            .build();
+
+        testChallenge = Challenge.builder()
+            .build();
+    }
+
+    // ========================
+    // 피드 신고 테스트
+    // ========================
+
+    @Test
+    @DisplayName("피드 신고 성공 - report 저장 및 reportCount 증가")
+    void reportFeed_success() {
+        // given
+        FeedReportReqDTO reqDTO = new FeedReportReqDTO();
+        reqDTO.setReason(FeedReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(feedRepository.findById(1L)).thenReturn(Optional.of(testFeed));
+        when(reportRepository.existsByMemberIdAndFeedId(1L, 1L)).thenReturn(false);
+
+        // when
+        reportService.reportFeed(1L, 1L, reqDTO);
+
+        // then
+        ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getReportType()).isEqualTo(ReportType.FEED);
+        assertThat(captor.getValue().getReason()).isEqualTo(FeedReportReason.SPAM.name());
+        assertThat(testFeed.getReportCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("피드 신고 3회 누적 시 isHidden = true 처리")
+    void reportFeed_hideWhenThresholdReached() {
+        // given — reportCount를 2로 설정하여 이번 신고가 3번째가 되도록
+        Feed feedWithTwoReports = Feed.builder().build();
+        feedWithTwoReports.incrementReportCount();
+        feedWithTwoReports.incrementReportCount();
+
+        FeedReportReqDTO reqDTO = new FeedReportReqDTO();
+        reqDTO.setReason(FeedReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(feedRepository.findById(1L)).thenReturn(Optional.of(feedWithTwoReports));
+        when(reportRepository.existsByMemberIdAndFeedId(1L, 1L)).thenReturn(false);
+
+        // when
+        reportService.reportFeed(1L, 1L, reqDTO);
+
+        // then
+        assertThat(feedWithTwoReports.getReportCount()).isEqualTo(3);
+        assertThat(feedWithTwoReports.getIsHidden()).isTrue();
+    }
+
+    @Test
+    @DisplayName("피드 신고 - 중복 신고 시 ALREADY_REPORTED 예외")
+    void reportFeed_alreadyReported() {
+        // given
+        FeedReportReqDTO reqDTO = new FeedReportReqDTO();
+        reqDTO.setReason(FeedReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(feedRepository.findById(1L)).thenReturn(Optional.of(testFeed));
+        when(reportRepository.existsByMemberIdAndFeedId(1L, 1L)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportFeed(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.ALREADY_REPORTED));
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("피드 신고 - 이미 숨김 처리된 피드 신고 시 ALREADY_HIDDEN_FEED 예외")
+    void reportFeed_alreadyHidden() {
+        // given
+        Feed hiddenFeed = Feed.builder().build();
+        hiddenFeed.hide();
+
+        FeedReportReqDTO reqDTO = new FeedReportReqDTO();
+        reqDTO.setReason(FeedReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(feedRepository.findById(1L)).thenReturn(Optional.of(hiddenFeed));
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportFeed(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.ALREADY_HIDDEN_FEED));
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("피드 신고 - ETC 사유에 detail 미입력 시 MISSING_REPORT_DETAIL 예외")
+    void reportFeed_etcWithoutDetail() {
+        // given
+        FeedReportReqDTO reqDTO = new FeedReportReqDTO();
+        reqDTO.setReason(FeedReportReason.ETC);
+        reqDTO.setDetail(null);
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportFeed(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.MISSING_REPORT_DETAIL));
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("피드 신고 - ETC 사유에 공백만 입력 시 MISSING_REPORT_DETAIL 예외")
+    void reportFeed_etcWithBlankDetail() {
+        // given
+        FeedReportReqDTO reqDTO = new FeedReportReqDTO();
+        reqDTO.setReason(FeedReportReason.ETC);
+        reqDTO.setDetail("   ");
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportFeed(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.MISSING_REPORT_DETAIL));
+    }
+
+    // ========================
+    // 챌린지 신고 테스트
+    // ========================
+
+    @Test
+    @DisplayName("챌린지 신고 성공 - report 저장 및 reportCount 증가")
+    void reportChallenge_success() {
+        // given
+        ChallengeReportReqDTO reqDTO = new ChallengeReportReqDTO();
+        reqDTO.setReason(ChallengeReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(challengeRepository.findById(1L)).thenReturn(Optional.of(testChallenge));
+        when(reportRepository.existsByMemberIdAndChallengeId(1L, 1L)).thenReturn(false);
+
+        // when
+        reportService.reportChallenge(1L, 1L, reqDTO);
+
+        // then
+        ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getReportType()).isEqualTo(ReportType.CHALLENGE);
+        assertThat(captor.getValue().getReason()).isEqualTo(ChallengeReportReason.SPAM.name());
+        assertThat(testChallenge.getReportCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("챌린지 신고 3회 누적 시 챌린지·피드 일괄 숨김 처리")
+    void reportChallenge_hideWithFeedsWhenThresholdReached() {
+        // given — reportCount를 2로 설정하여 이번 신고가 3번째가 되도록
+        Challenge challengeWithTwoReports = Challenge.builder().build();
+        challengeWithTwoReports.incrementReportCount();
+        challengeWithTwoReports.incrementReportCount();
+
+        ChallengeReportReqDTO reqDTO = new ChallengeReportReqDTO();
+        reqDTO.setReason(ChallengeReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(challengeRepository.findById(1L)).thenReturn(Optional.of(challengeWithTwoReports));
+        when(reportRepository.existsByMemberIdAndChallengeId(1L, 1L)).thenReturn(false);
+
+        // when
+        reportService.reportChallenge(1L, 1L, reqDTO);
+
+        // then
+        assertThat(challengeWithTwoReports.getReportCount()).isEqualTo(3);
+        assertThat(challengeWithTwoReports.getIsHidden()).isTrue();
+        // 피드 일괄 숨김 쿼리 호출 확인
+        verify(feedRepository, times(1)).hideAllByChallengeId(1L);
+    }
+
+    @Test
+    @DisplayName("챌린지 신고 - 중복 신고 시 ALREADY_REPORTED 예외")
+    void reportChallenge_alreadyReported() {
+        // given
+        ChallengeReportReqDTO reqDTO = new ChallengeReportReqDTO();
+        reqDTO.setReason(ChallengeReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(challengeRepository.findById(1L)).thenReturn(Optional.of(testChallenge));
+        when(reportRepository.existsByMemberIdAndChallengeId(1L, 1L)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportChallenge(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.ALREADY_REPORTED));
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("챌린지 신고 - 이미 숨김 처리된 챌린지 신고 시 ALREADY_HIDDEN_CHALLENGE 예외")
+    void reportChallenge_alreadyHidden() {
+        // given
+        Challenge hiddenChallenge = Challenge.builder().build();
+        hiddenChallenge.hide();
+
+        ChallengeReportReqDTO reqDTO = new ChallengeReportReqDTO();
+        reqDTO.setReason(ChallengeReportReason.SPAM);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(challengeRepository.findById(1L)).thenReturn(Optional.of(hiddenChallenge));
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportChallenge(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.ALREADY_HIDDEN_CHALLENGE));
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("챌린지 신고 - ETC 사유에 detail 미입력 시 MISSING_REPORT_DETAIL 예외")
+    void reportChallenge_etcWithoutDetail() {
+        // given
+        ChallengeReportReqDTO reqDTO = new ChallengeReportReqDTO();
+        reqDTO.setReason(ChallengeReportReason.ETC);
+        reqDTO.setDetail(null);
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportChallenge(1L, 1L, reqDTO))
+            .isInstanceOf(BaseException.class)
+            .satisfies(e -> assertThat(((BaseException) e).getBaseResponseCode())
+                .isEqualTo(BaseResponseCode.MISSING_REPORT_DETAIL));
+
+        verify(reportRepository, never()).save(any());
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
     password:
   jpa:
     database: h2
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
     properties:
@@ -40,6 +41,8 @@ spring:
       credentials:
         accessKey: test-access-key
         secretKey: test-secret-key
+      stack:
+        auto: false
       region:
         static: ap-northeast-2
       s3:


### PR DESCRIPTION
## 📌 이슈 번호

- closed #108

## 🍬 기능 설명

- 피드 및 챌린지에 대한 앱 내 신고 기능 구현 (기존 외부 폼 방식에서 전환)
- 신고 접수 시 `report` 레코드 저장 및 `report_count` 증가
- 누적 신고 3회 도달 시 즉시 `is_hidden = true` 자동 숨김 처리
- 챌린지 숨김 시 해당 챌린지의 모든 피드도 연쇄 숨김 처리
- 숨김 처리된 피드·챌린지는 모든 조회 API에서 자동 제외
- 중복 신고 방지 (한 회원이 같은 피드/챌린지를 1회만 신고 가능)

### 신고 사유

**피드:** 친환경 목적과 무관함 / 허위·조작 이미지 / 스팸·광고 / 선정적·폭력적 이미지 / 기타(직접 입력)

**챌린지:** 친환경 목적과 무관함 / 스팸·광고 / 부적절한 내용 / 위험·불법 행위 유도 / 기타(직접 입력)

### API

| 메서드 | URL | 설명 |
|--------|-----|------|
| POST | `/feed/{feedId}/report` | 피드 신고 |
| POST | `/challenge/{challengeId}/report` | 챌린지 신고 |

## 🤔 코드 리뷰에서 집중적으로 볼 내용

**1. 집계 방식 — API 레이어 처리**

- DB 트리거 대신 서비스 레이어에서 `report_count` 증가 및 `is_hidden` 전환을 처리
- 동시 신고가 발생할 경우 카운트 정합성 문제가 생길 수 있는데, 현재 규모에서는 허용 범위로 판단
- 동시성 제어가 필요하다면 추후 낙관적 락 또는 DB 트리거 방식으로 전환을 검토할 수 있음

**2. 챌린지 숨김 시 피드 연쇄 숨김 — 벌크 UPDATE**

```java
// N번 UPDATE 방지를 위해 @Modifying + @Query로 단일 쿼리 처리
@Modifying
@Query("UPDATE Feed f SET f.isHidden = true WHERE f.challenge.id = :challengeId")
void hideAllByChallengeId(@Param("challengeId") Long challengeId);
```

**3. 임계치 상수 관리**

```java
private static final int REPORT_THRESHOLD = 3;
```

- 현재는 서비스 내 상수로 관리
- 추후 운영 중 동적 변경이 필요하면 DB 정책 테이블로 이관 고려 필요

## ⭐ 기타 사항

- 오신고 복구는 운영자가 `report.status`를 `DISMISSED`로 변경하고 `is_hidden`을 수동 복구하는 방식으로 처리
- 기존 테스트 오류 4건 함께 수정
  - `ChallengeServiceImplTest`: `uploadFile` 시그니처 불일치, mock 누락
  - `ChallengeRepositoryImplTest`: H2 Dialect 미지정으로 인한 DDL 오류
  - `BeilsangServerV2ApplicationTests`: 외부 환경변수 의존 통합 테스트 `@Disabled` 처리
