### PR TITLE
[Feat] 뱃지 획득 기능

### DIFF
--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/controller/BadgeController.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/controller/BadgeController.java
@@ -1,0 +1,77 @@
+package site.beilsang.beilsang_server_v2.domain.badge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.BadgeResDTO;
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.RepresentativeBadgeResDTO;
+import site.beilsang.beilsang_server_v2.domain.badge.service.BadgeService;
+import site.beilsang.beilsang_server_v2.global.common.BaseResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/badge")
+@Tag(name = "Badge", description = "나의 배지 API")
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    // ── 내 배지 전체 목록 조회 ────────────────────────────────────────────────
+    @Operation(
+        summary = "내 배지 전체 목록 조회",
+        description = "로그인한 멤버가 보유한 전체 배지 목록을 반환합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "배지 목록 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @GetMapping
+    public BaseResponse<List<BadgeResDTO>> getMyBadgeList(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(badgeService.getMyBadgeList(memberId));
+    }
+
+    // ── 대표 배지 조회 ────────────────────────────────────────────────────────
+    @Operation(
+        summary = "대표 배지 조회",
+        description = "로그인한 멤버의 대표 배지를 반환합니다. 미설정 시 null을 반환합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "대표 배지 조회 성공 (미설정 시 null)"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @GetMapping("/representative")
+    public BaseResponse<BadgeResDTO> getRepresentativeBadge(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return new BaseResponse<>(badgeService.getRepresentativeBadge(memberId));
+    }
+
+    // ── 대표 배지 설정 / 해제 ─────────────────────────────────────────────────
+    @Operation(
+        summary = "대표 배지 설정 / 해제",
+        description = "4단계(숲) 카테고리 배지를 대표 배지로 설정합니다. memberBadgeId를 null로 전달하면 대표 배지가 해제됩니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "대표 배지 설정/해제 성공"),
+        @ApiResponse(responseCode = "400", description = "4단계 미달 배지로 설정 시도"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "멤버 또는 배지를 찾을 수 없음")
+    })
+    @PatchMapping("/representative")
+    public BaseResponse<Void> updateRepresentativeBadge(
+        Authentication authentication,
+        @RequestBody RepresentativeBadgeResDTO requestDTO
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        badgeService.updateRepresentativeBadge(memberId, requestDTO);
+        return new BaseResponse<>();
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/BadgeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/BadgeAssembler.java
@@ -1,0 +1,22 @@
+package site.beilsang.beilsang_server_v2.domain.badge.dto;
+
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.BadgeResDTO;
+import site.beilsang.beilsang_server_v2.domain.member.entity.BadgeMember;
+
+import java.util.List;
+
+public class BadgeAssembler {
+    public static BadgeResDTO toBadgeResDTO(BadgeMember memberBadge) {
+        return BadgeResDTO.builder()
+            .badgeMemberId(memberBadge.getId())
+            .badgeId(memberBadge.getBadge().getId())
+            .badgeType(memberBadge.getBadge().getBadgeType())
+            .category(memberBadge.getBadge().getCategory())
+            .currentStep(memberBadge.getCurrentStep())
+            .acquiredAt(memberBadge.getAcquiredAt())
+            .build();
+    }
+    public static List<BadgeResDTO> toBadgeResDTOList(List<BadgeMember> badges) {
+        return badges.stream().map(BadgeAssembler::toBadgeResDTO).toList();
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/BadgeAssembler.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/BadgeAssembler.java
@@ -12,7 +12,7 @@ public class BadgeAssembler {
             .badgeId(memberBadge.getBadge().getId())
             .badgeType(memberBadge.getBadge().getBadgeType())
             .category(memberBadge.getBadge().getCategory())
-            .currentStep(memberBadge.getCurrentStep())
+            .currentStep(memberBadge.getStep())
             .acquiredAt(memberBadge.getAcquiredAt())
             .build();
     }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/BadgeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/BadgeResDTO.java
@@ -20,10 +20,10 @@ public class BadgeResDTO {
     private Long badgeId;
 
     @Schema(description = "활동 배지 타입", example = "CHALLENGE_START")
-    private BadgeType badgeType;  // 챌린지 배지는 null
+    private BadgeType badgeType;  // 활동 배지: CHALLENGE_*, 카테고리 배지: CATEGORY
 
     @Schema(description = "챌린지 배지 타입", example = "텀블러")
-    private Category category;    // 활동 배지는 null
+    private Category category;    // 카테고리 배지일 때만 값 존재(활동 배지는 null)
 
     @Schema(description = "챌린지 배지 단계", example = "1~4")
     private Integer currentStep;  // 활동 배지는 null

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/BadgeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/BadgeResDTO.java
@@ -3,8 +3,8 @@ package site.beilsang.beilsang_server_v2.domain.badge.dto.res;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +20,7 @@ public class BadgeResDTO {
     private Long badgeId;
 
     @Schema(description = "활동 배지 타입", example = "CHALLENGE_START")
-    private ChallengeBadgeType badgeType;  // 챌린지 배지는 null
+    private BadgeType badgeType;  // 챌린지 배지는 null
 
     @Schema(description = "챌린지 배지 타입", example = "텀블러")
     private Category category;    // 활동 배지는 null

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/BadgeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/BadgeResDTO.java
@@ -1,0 +1,33 @@
+package site.beilsang.beilsang_server_v2.domain.badge.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "배지 응답 DTO")
+@Builder
+@Getter
+public class BadgeResDTO {
+
+    @Schema(description = "배지 멤버 ID", example = "1")
+    private Long badgeMemberId;
+
+    @Schema(description = "배지 ID", example = "1")
+    private Long badgeId;
+
+    @Schema(description = "활동 배지 타입", example = "CHALLENGE_START")
+    private ChallengeBadgeType badgeType;  // 챌린지 배지는 null
+
+    @Schema(description = "챌린지 배지 타입", example = "텀블러")
+    private Category category;    // 활동 배지는 null
+
+    @Schema(description = "챌린지 배지 단계", example = "1~4")
+    private Integer currentStep;  // 활동 배지는 null
+
+    @Schema(description = "획득 시간")
+    private LocalDateTime acquiredAt;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/RepresentativeBadgeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/RepresentativeBadgeResDTO.java
@@ -1,0 +1,12 @@
+package site.beilsang.beilsang_server_v2.domain.badge.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "대표 배지 설정/해제 DTO")
+@Builder
+@Getter
+public class RepresentativeBadgeResDTO {
+    private Long badgeMemberId;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/RepresentativeBadgeResDTO.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/dto/res/RepresentativeBadgeResDTO.java
@@ -1,12 +1,14 @@
 package site.beilsang.beilsang_server_v2.domain.badge.dto.res;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Schema(description = "대표 배지 설정/해제 DTO")
-@Builder
 @Getter
+@Setter
+@NoArgsConstructor
 public class RepresentativeBadgeResDTO {
     private Long badgeMemberId;
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
@@ -1,0 +1,39 @@
+package site.beilsang.beilsang_server_v2.domain.badge.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Badge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "badge_id")
+    private Long id;
+
+    /**
+     * 배지 종류
+     * - CHALLENGE_START   : 챌린지 시작 배지 (챌린지 1개 참여)
+     * - CHALLENGE_CREATE  : 챌린지 제작 배지 (챌린지 1개 제작)
+     * - CHALLENGE_VERIFY  : 챌린지 인증 배지 (인증 피드 1개 인증)
+     * - CATEGORY          : 카테고리 배지    (카테고리별 챌린지 성공 수에 따라 1~3단계)
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChallengeBadgeType badgeType;
+
+    /**
+     * 카테고리 배지일 때만 사용. 활동 배지(CHALLENGE_*)는 null.
+     */
+    @Enumerated(EnumType.STRING)
+    private Category category;
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
@@ -28,7 +28,7 @@ public class Badge {
      * - CHALLENGE_START   : 챌린지 시작 배지 (챌린지 1개 참여)
      * - CHALLENGE_CREATE  : 챌린지 제작 배지 (챌린지 1개 제작)
      * - CHALLENGE_VERIFY  : 챌린지 인증 배지 (인증 피드 1개 인증)
-     * - CATEGORY          : 카테고리 배지    (카테고리별 챌린지 성공 수에 따라 1~3단계)
+     * - CATEGORY          : 챌린지 배지    (카테고리별 챌린지 성공 수에 따라 1~4단계)
      */
     @Enumerated(EnumType.STRING)
     @Column(name = "badge_type", nullable = false)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 
 @Entity
 @Getter
@@ -28,8 +28,8 @@ public class Badge {
      * - CATEGORY          : 카테고리 배지    (카테고리별 챌린지 성공 수에 따라 1~3단계)
      */
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ChallengeBadgeType badgeType;
+    @Column(name = "badge_type", nullable = false, unique = true)
+    private BadgeType badgeType;
 
     /**
      * 카테고리 배지일 때만 사용. 활동 배지(CHALLENGE_*)는 null.

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/entity/Badge.java
@@ -9,6 +9,9 @@ import site.beilsang.beilsang_server_v2.global.enums.Category;
 import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 
 @Entity
+@Table(name = "badge", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"badge_type", "category"})
+})
 @Getter
 @Builder
 @NoArgsConstructor
@@ -28,7 +31,7 @@ public class Badge {
      * - CATEGORY          : 카테고리 배지    (카테고리별 챌린지 성공 수에 따라 1~3단계)
      */
     @Enumerated(EnumType.STRING)
-    @Column(name = "badge_type", nullable = false, unique = true)
+    @Column(name = "badge_type", nullable = false)
     private BadgeType badgeType;
 
     /**

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/repository/BadgeRepository.java
@@ -1,11 +1,17 @@
 package site.beilsang.beilsang_server_v2.domain.badge.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import site.beilsang.beilsang_server_v2.domain.badge.entity.Badge;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 
 import java.util.Optional;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
-    Optional<Badge> findByBadgeType(ChallengeBadgeType badgeType);
+    @Query("SELECT b FROM Badge b WHERE b.badgeType = :badgeType")
+    Optional<Badge> findByBadgeType(@Param("badgeType") BadgeType badgeType);
+
+    @Query("SELECT COUNT(b) > 0 FROM Badge b WHERE b.badgeType = :badgeType")
+    boolean existsByBadgeType(@Param("badgeType") BadgeType badgeType);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/repository/BadgeRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.beilsang.beilsang_server_v2.domain.badge.entity.Badge;
 import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
 
 import java.util.Optional;
 
@@ -14,4 +15,8 @@ public interface BadgeRepository extends JpaRepository<Badge, Long> {
 
     @Query("SELECT COUNT(b) > 0 FROM Badge b WHERE b.badgeType = :badgeType")
     boolean existsByBadgeType(@Param("badgeType") BadgeType badgeType);
+
+    Optional<Badge> findByCategory(Category category);
+
+    Boolean existsByCategory(Category category);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/repository/BadgeRepository.java
@@ -1,0 +1,11 @@
+package site.beilsang.beilsang_server_v2.domain.badge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.beilsang.beilsang_server_v2.domain.badge.entity.Badge;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+
+import java.util.Optional;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+    Optional<Badge> findByBadgeType(ChallengeBadgeType badgeType);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
@@ -2,7 +2,7 @@ package site.beilsang.beilsang_server_v2.domain.badge.service;
 
 import site.beilsang.beilsang_server_v2.domain.badge.dto.res.BadgeResDTO;
 import site.beilsang.beilsang_server_v2.domain.badge.dto.res.RepresentativeBadgeResDTO;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 
 import java.util.List;
 
@@ -25,5 +25,5 @@ public interface BadgeService {
      * @param memberId  배지를 받을 멤버 ID
      * @param badgeType CHALLENGE_START | CHALLENGE_CREATE | CHALLENGE_VERIFY
      */
-    void grantActivityBadgeIfFirst(Long memberId, ChallengeBadgeType badgeType);
+    void grantActivityBadgeIfFirst(Long memberId, BadgeType badgeType);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
@@ -29,6 +29,6 @@ public interface BadgeService {
     void grantActivityBadgeIfFirst(Long memberId, BadgeType badgeType);
 
 
-    /** 챌린지 인증 시 카테고리 뱃지 갯수 +1  */
+    /** 챌린지 정산(성공) 시 카테고리 뱃지 성공 횟수 +1 */
     void incrementCategoryBadgeCount(Long memberId, Category category);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
@@ -1,0 +1,29 @@
+package site.beilsang.beilsang_server_v2.domain.badge.service;
+
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.BadgeResDTO;
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.RepresentativeBadgeResDTO;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+
+import java.util.List;
+
+public interface BadgeService {
+
+    /** 내 배지 전체 목록 조회 */
+    List<BadgeResDTO> getMyBadgeList(Long memberId);
+
+    /** 대표 배지 조회 (미설정 시 null 반환) */
+    BadgeResDTO getRepresentativeBadge(Long memberId);
+
+    /** 대표 배지 설정 또는 해제 (requestDTO.memberBadgeId == null 이면 해제) */
+    void updateRepresentativeBadge(Long memberId, RepresentativeBadgeResDTO requestDTO);
+
+    /**
+     * 활동 배지 최초 1회 부여
+     * 이미 해당 BadgeType의 MemberBadge가 존재하면 아무것도 하지 않음
+     * ChallengeService, FeedService에서 호출
+     *
+     * @param memberId  배지를 받을 멤버 ID
+     * @param badgeType CHALLENGE_START | CHALLENGE_CREATE | CHALLENGE_VERIFY
+     */
+    void grantActivityBadgeIfFirst(Long memberId, ChallengeBadgeType badgeType);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeService.java
@@ -3,6 +3,7 @@ package site.beilsang.beilsang_server_v2.domain.badge.service;
 import site.beilsang.beilsang_server_v2.domain.badge.dto.res.BadgeResDTO;
 import site.beilsang.beilsang_server_v2.domain.badge.dto.res.RepresentativeBadgeResDTO;
 import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
 
 import java.util.List;
 
@@ -26,4 +27,8 @@ public interface BadgeService {
      * @param badgeType CHALLENGE_START | CHALLENGE_CREATE | CHALLENGE_VERIFY
      */
     void grantActivityBadgeIfFirst(Long memberId, BadgeType badgeType);
+
+
+    /** 챌린지 인증 시 카테고리 뱃지 갯수 +1  */
+    void incrementCategoryBadgeCount(Long memberId, Category category);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeServiceImpl.java
@@ -1,0 +1,109 @@
+package site.beilsang.beilsang_server_v2.domain.badge.service;
+
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.beilsang.beilsang_server_v2.domain.badge.dto.BadgeAssembler;
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.BadgeResDTO;
+import site.beilsang.beilsang_server_v2.domain.badge.dto.res.RepresentativeBadgeResDTO;
+import site.beilsang.beilsang_server_v2.domain.badge.entity.Badge;
+import site.beilsang.beilsang_server_v2.domain.badge.repository.BadgeRepository;
+import site.beilsang.beilsang_server_v2.domain.member.entity.BadgeMember;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.domain.member.repository.BadgeMemberRepository;
+import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
+import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BadgeServiceImpl implements BadgeService {
+
+    private final BadgeRepository badgeRepository;
+    private final BadgeMemberRepository badgeMemberRepository;
+    private final MemberRepository memberRepository;
+
+    // ── 내 배지 전체 목록 조회 ────────────────────────────────────────────────
+    @Override
+    public List<BadgeResDTO> getMyBadgeList(Long memberId) {
+        List<BadgeMember> memberBadges =
+            badgeMemberRepository.findAllByMemberIdWithBadge(memberId);
+        return BadgeAssembler.toBadgeResDTOList(memberBadges);
+    }
+
+    // ── 대표 배지 조회 ────────────────────────────────────────────────────────
+    @Override
+    public BadgeResDTO getRepresentativeBadge(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+
+        // 대표 배지 미설정 시 null 반환
+        if (member.getRepresentativeBadge() == null) {
+            return null;
+        }
+
+        return BadgeAssembler.toBadgeResDTO(member.getRepresentativeBadge());
+    }
+
+    // ── 대표 배지 설정 / 해제 ─────────────────────────────────────────────────
+    @Override
+    @Transactional
+    public void updateRepresentativeBadge(Long memberId, RepresentativeBadgeResDTO requestDTO) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+
+        // memberBadgeId == null 이면 대표 배지 해제
+        if (requestDTO.getBadgeMemberId() == null) {
+            member.updateRepresentativeBadge(null);
+            return;
+        }
+
+        // 본인이 보유한 배지인지 확인
+        BadgeMember badgeMember = badgeMemberRepository
+            .findByIdAndMemberId(requestDTO.getBadgeMemberId(), memberId)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER_BADGE));
+
+        // 4단계(숲) 카테고리 배지인지 검증 (Member.updateRepresentativeBadge 내부에서도 검증)
+        if (!badgeMember.isEligibleForRepresentative()) {
+            throw new BaseException(NOT_ELIGIBLE_BADGE);
+        }
+
+        member.updateRepresentativeBadge(badgeMember);
+    }
+    /**
+     * ChallengeService, FeedService에서 호출.
+     * 이미 해당 BadgeType의 MemberBadge가 존재하면 조용히 종료 (예외 없음).
+     * 호출부의 트랜잭션에 참여하므로 별도 @Transactional 불필요.
+     */
+    @Override
+    @Transactional
+    public void grantActivityBadgeIfFirst(Long memberId, ChallengeBadgeType badgeType) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+        // 이미 보유한 배지면 중단
+        if (badgeMemberRepository.existsByMemberAndChallengeBadgeType(member, badgeType)) {
+            return;
+        }
+
+
+        // 기준 Badge 데이터 조회 (DB에 미리 insert된 기준 데이터)
+        Badge badge = badgeRepository.findByBadgeType(badgeType)
+            .orElseThrow(() -> new BaseException(NOT_FOUND_BADGE));
+
+        BadgeMember memberBadge = BadgeMember.builder()
+            .member(member)
+            .badge(badge)
+            .acquiredAt(LocalDateTime.now())
+            .currentStep(null)  // 활동 배지는 단계 없음
+            .build();
+
+        badgeMemberRepository.save(memberBadge);
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeServiceImpl.java
@@ -1,5 +1,6 @@
 package site.beilsang.beilsang_server_v2.domain.badge.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,8 +14,7 @@ import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.domain.member.repository.BadgeMemberRepository;
 import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
-import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,6 +22,7 @@ import java.util.List;
 import static site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode.*;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BadgeServiceImpl implements BadgeService {
@@ -79,16 +80,18 @@ public class BadgeServiceImpl implements BadgeService {
     }
     /**
      * ChallengeService, FeedService에서 호출.
-     * 이미 해당 BadgeType의 MemberBadge가 존재하면 조용히 종료 (예외 없음).
+     * 이미 해당 BadgeType의 MemberBadge가 존재하면 종료
      * 호출부의 트랜잭션에 참여하므로 별도 @Transactional 불필요.
      */
+
+    // ── 챌린지 인증 뱃지 부여 ─────────────────────────────────────────────────
     @Override
     @Transactional
-    public void grantActivityBadgeIfFirst(Long memberId, ChallengeBadgeType badgeType) {
+    public void grantActivityBadgeIfFirst(Long memberId, BadgeType badgeType) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
         // 이미 보유한 배지면 중단
-        if (badgeMemberRepository.existsByMemberAndChallengeBadgeType(member, badgeType)) {
+        if (badgeMemberRepository.existsByMemberAndBadge_BadgeType(member, badgeType)) {
             return;
         }
 

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/badge/service/BadgeServiceImpl.java
@@ -15,9 +15,11 @@ import site.beilsang.beilsang_server_v2.domain.member.repository.BadgeMemberRepo
 import site.beilsang.beilsang_server_v2.domain.member.repository.MemberRepository;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode.*;
 
@@ -104,9 +106,40 @@ public class BadgeServiceImpl implements BadgeService {
             .member(member)
             .badge(badge)
             .acquiredAt(LocalDateTime.now())
-            .currentStep(null)  // 활동 배지는 단계 없음
+            .count(1)  // 활동 배지는 단계 없음
             .build();
 
         badgeMemberRepository.save(memberBadge);
+    }
+
+    // ── 카테고리 챌린지 성공 횟수 누적 ──────────────────────────────────────
+    @Override
+    @Transactional
+    public void incrementCategoryBadgeCount(Long memberId, Category category) {
+
+        Optional<BadgeMember> optionalBadgeMember =
+            badgeMemberRepository.findByMemberIdAndBadgeCategory(memberId, category);
+
+        if (optionalBadgeMember.isPresent()) {
+            // 1. 이미 배지를 소유하고 있다면 횟수만 1 증가
+            BadgeMember badgeMember = optionalBadgeMember.get();
+            badgeMember.addCount();
+        } else {
+            // 2. 해당 카테고리 배지가 아예 없는 상태에서 첫 성공을 했다면 (생성 + count 1)
+            Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+
+            Badge badge = badgeRepository.findByCategory(category)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_BADGE));
+
+            BadgeMember newBadgeMember = BadgeMember.builder()
+                .member(member)
+                .badge(badge)
+                .acquiredAt(LocalDateTime.now())
+                .count(1) // 방금 1회 성공했으므로 1
+                .build();
+
+            badgeMemberRepository.save(newBadgeMember);
+        }
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -139,7 +139,7 @@ public class ChallengeServiceImpl implements ChallengeService {
             .build());
 
         //챌린지 제작 배지 부여 (최초 1회)
-        badgeService.grantActivityBadgeIfFirst(memberId, ChallengeBadgeType.CHALLENGE_CREATE);
+        badgeService.grantActivityBadgeIfFirst(memberId, BadgeType.CHALLENGE_CREATE);
 
         return ChallengeAssembler.toChallengeResDTO(challenge);
     }
@@ -459,7 +459,7 @@ public class ChallengeServiceImpl implements ChallengeService {
             .build());
 
         //챌린지 시작 배지 부여 (최초 1회)
-        badgeService.grantActivityBadgeIfFirst(memberId, ChallengeBadgeType.CHALLENGE_START);
+        badgeService.grantActivityBadgeIfFirst(memberId, BadgeType.CHALLENGE_START);
 
         // 챌린지 참여자 수 증가
         challenge.incrementAttendeeCount();

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import site.beilsang.beilsang_server_v2.domain.badge.service.BadgeService;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.ChallengeAssembler;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ChallengeListReqDTO;
 import site.beilsang.beilsang_server_v2.domain.challenge.dto.req.ClosedChallengeListReqDTO;
@@ -45,11 +46,7 @@ import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.PageResponseDTO;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeMemberStatus;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeStatus;
-import site.beilsang.beilsang_server_v2.global.enums.PointName;
-import site.beilsang.beilsang_server_v2.global.enums.PointStatus;
-import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
+import site.beilsang.beilsang_server_v2.global.enums.*;
 
 @Service
 @RequiredArgsConstructor
@@ -70,6 +67,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final PointService pointService;
     private final S3Service s3Service;
     private final ChallengeAssembler challengeAssembler;
+    private final BadgeService badgeService;
 
     @Override
     public ChallengeResDTO createChallenge(Long memberId,
@@ -139,6 +137,9 @@ public class ChallengeServiceImpl implements ChallengeService {
             .member(member)
             .challenge(challenge)
             .build());
+
+        //챌린지 제작 배지 부여 (최초 1회)
+        badgeService.grantActivityBadgeIfFirst(memberId, ChallengeBadgeType.CHALLENGE_CREATE);
 
         return ChallengeAssembler.toChallengeResDTO(challenge);
     }
@@ -456,6 +457,9 @@ public class ChallengeServiceImpl implements ChallengeService {
             .member(member)
             .challenge(challenge)
             .build());
+
+        //챌린지 시작 배지 부여 (최초 1회)
+        badgeService.grantActivityBadgeIfFirst(memberId, ChallengeBadgeType.CHALLENGE_START);
 
         // 챌린지 참여자 수 증가
         challenge.incrementAttendeeCount();

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeSettlementService.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/challenge/service/ChallengeSettlementService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.beilsang.beilsang_server_v2.domain.badge.service.BadgeService;
 import site.beilsang.beilsang_server_v2.domain.challenge.entity.Challenge;
 import site.beilsang.beilsang_server_v2.domain.member.entity.ChallengeMember;
 import site.beilsang.beilsang_server_v2.domain.member.repository.ChallengeMemberRepository;
@@ -21,6 +22,7 @@ public class ChallengeSettlementService {
 
     private final ChallengeMemberRepository challengeMemberRepository;
     private final PointService pointService;
+    private final BadgeService badgeService;
 
     // TODO: 호스트 보너스 정책 미확정 — 추후 논의 안건 상정 필요
     private static final int HOST_BONUS_POINT = 0;
@@ -57,13 +59,16 @@ public class ChallengeSettlementService {
         // 3. 성공/실패 판정
         List<ChallengeMember> successMembers = judgeMembers(challenge, ongoingMembers);
 
-        // 4. 포인트 정산
-        if (successMembers.isEmpty()) {
+        if (!successMembers.isEmpty()) {
+            // 4. 성공 멤버 배지 획득(카운트 증가) 처리
+            grantCategoryBadges(challenge, successMembers);
+
+            // 5. 포인트 정산
+            distributePoints(challenge, successMembers);
+        } else {
             // 전원 실패 시 포인트 분배 없음 (collectedPoint 소멸)
             log.info("챌린지 ID: {} — 전원 실패. collectedPoint {} 소멸",
                 challenge.getId(), challenge.getCollectedPoint());
-        } else {
-            distributePoints(challenge, successMembers);
         }
 
         // 5. 정산 완료 표시
@@ -135,5 +140,22 @@ public class ChallengeSettlementService {
                     challenge.getId(), challengeMember.getMember().getId(), HOST_BONUS_POINT);
             }
         }
+    }
+
+    /**
+     * 성공 멤버들에게 카테고리 뱃지 획득(카운트 증가) 처리를 합니다.
+     *
+     * @param challenge      정산 대상 챌린지
+     * @param successMembers 성공한 챌린지 멤버 목록
+     */
+    private void grantCategoryBadges(Challenge challenge, List<ChallengeMember> successMembers) {
+        for (ChallengeMember member : successMembers) {
+            badgeService.incrementCategoryBadgeCount(
+                member.getMember().getId(),
+                challenge.getCategory()
+            );
+        }
+        log.info("챌린지 ID: {} — 성공 멤버 {}명에 대해 카테고리({}) 뱃지 갱신 완료",
+            challenge.getId(), successMembers.size(), challenge.getCategory());
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import site.beilsang.beilsang_server_v2.domain.badge.service.BadgeService;
 import site.beilsang.beilsang_server_v2.domain.challenge.repository.ChallengeRepository;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.FeedAssembler;
 import site.beilsang.beilsang_server_v2.domain.feed.dto.req.FeedCreateReqDTO;
@@ -31,6 +32,7 @@ import site.beilsang.beilsang_server_v2.global.common.SliceResponseDTO;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 
 @Service
@@ -44,6 +46,7 @@ public class FeedServiceImpl implements FeedService {
     private final MemberRepository memberRepository;
     private final ChallengeRepository challengeRepository;
     private final S3Service s3Service;
+    private final BadgeService badgeService;
 
     @Override
     public SliceResponseDTO<PreviewFeedResDTO> getFeedList(Long memberId,
@@ -120,6 +123,10 @@ public class FeedServiceImpl implements FeedService {
 
         // Feed 저장
         Feed savedFeed = feedRepository.save(feed);
+
+        //챌린지 인증 배지 부여 (최초 1회)
+        badgeService.grantActivityBadgeIfFirst(memberId, ChallengeBadgeType.CHALLENGE_VERIFY);
+
 
         // FeedAssembler를 사용하여 FeedCreateResDTO 생성 및 반환
         return FeedAssembler.toFeedCreateResDTO(savedFeed);

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/feed/service/FeedServiceImpl.java
@@ -31,8 +31,8 @@ import site.beilsang.beilsang_server_v2.global.aws.s3.S3Service;
 import site.beilsang.beilsang_server_v2.global.common.SliceResponseDTO;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseException;
 import site.beilsang.beilsang_server_v2.global.common.exception.BaseResponseCode;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 import site.beilsang.beilsang_server_v2.global.enums.Category;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
 import site.beilsang.beilsang_server_v2.global.enums.UploadPath;
 
 @Service
@@ -125,7 +125,7 @@ public class FeedServiceImpl implements FeedService {
         Feed savedFeed = feedRepository.save(feed);
 
         //챌린지 인증 배지 부여 (최초 1회)
-        badgeService.grantActivityBadgeIfFirst(memberId, ChallengeBadgeType.CHALLENGE_VERIFY);
+        badgeService.grantActivityBadgeIfFirst(memberId, BadgeType.CHALLENGE_VERIFY);
 
 
         // FeedAssembler를 사용하여 FeedCreateResDTO 생성 및 반환

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/BadgeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/BadgeMember.java
@@ -35,24 +35,42 @@ public class BadgeMember {
     private LocalDateTime acquiredAt;
 
     /**
-     * 카테고리 배지의 현재 단계 (1~4단계 / 활동 배지는 null)
-     * 1단계(새싹) : 해당 카테고리 챌린지  1개 성공
-     * 2단계(씨앗) : 해당 카테고리 챌린지  3개 성공
-     * 3단계(나무) : 해당 카테고리 챌린지 10개 성공
-     * 4단계(숲)   : 해당 카테고리 챌린지 ??개 성공 (조건 확정 후 서비스 레이어에 반영)
+     * 카테고리 배지의 현재 획득 개수
+     * 1단계(새싹) : 해당 카테고리 챌린지  0개 성공
+     * 2단계(씨앗) : 해당 카테고리 챌린지  1개 성공
+     * 3단계(나무) : 해당 카테고리 챌린지  3개 성공
+     * 4단계(숲)   : 해당 카테고리 챌린지 10개 성공
      */
-    private Integer currentStep;
+    private Integer count;
 
     // -------------------------------------------------------
     // 비즈니스 메서드
     // -------------------------------------------------------
 
     /**
-     * 카테고리 배지 단계 업그레이드 (최대 4단계)
+     * 카테고리 챌린지 성공 시 카운트 증가
      */
-    public void upgradeStep() {
-        if (this.currentStep != null && this.currentStep < 4) {
-            this.currentStep++;
+    public void addCount() {
+        if (this.count == null) {
+            this.count = 0;
+        }
+        this.count++;
+    }
+
+    /**
+     * 카테고리 배지 단계 계산 (최대 4단계)
+     */
+    public int getStep() {
+        if (this.count == null) return 1; // 방어 로직 (활동 배지 등의 경우)
+
+        if (this.count >= 10) {
+            return 4; // 숲
+        } else if (this.count >= 3) {
+            return 3; // 나무
+        } else if (this.count >= 1) {
+            return 2; // 씨앗
+        } else {
+            return 1; // 새싹
         }
     }
 
@@ -60,6 +78,6 @@ public class BadgeMember {
      * 대표 배지 설정 가능 여부 — 4단계(숲)에 도달한 카테고리 배지만 가능
      */
     public boolean isEligibleForRepresentative() {
-        return this.currentStep != null && this.currentStep == 4;
+        return getStep() == 4;
     }
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/BadgeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/BadgeMember.java
@@ -1,0 +1,65 @@
+package site.beilsang.beilsang_server_v2.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.beilsang.beilsang_server_v2.domain.badge.entity.Badge;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BadgeMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_badge_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id", nullable = false)
+    private Badge badge;
+
+    /**
+     * 배지 최초 획득 시각
+     */
+    @Column(nullable = false)
+    private LocalDateTime acquiredAt;
+
+    /**
+     * 카테고리 배지의 현재 단계 (1~4단계 / 활동 배지는 null)
+     * 1단계(새싹) : 해당 카테고리 챌린지  1개 성공
+     * 2단계(씨앗) : 해당 카테고리 챌린지  3개 성공
+     * 3단계(나무) : 해당 카테고리 챌린지 10개 성공
+     * 4단계(숲)   : 해당 카테고리 챌린지 ??개 성공 (조건 확정 후 서비스 레이어에 반영)
+     */
+    private Integer currentStep;
+
+    // -------------------------------------------------------
+    // 비즈니스 메서드
+    // -------------------------------------------------------
+
+    /**
+     * 카테고리 배지 단계 업그레이드 (최대 4단계)
+     */
+    public void upgradeStep() {
+        if (this.currentStep != null && this.currentStep < 4) {
+            this.currentStep++;
+        }
+    }
+
+    /**
+     * 대표 배지 설정 가능 여부 — 4단계(숲)에 도달한 카테고리 배지만 가능
+     */
+    public boolean isEligibleForRepresentative() {
+        return this.currentStep != null && this.currentStep == 4;
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/BadgeMember.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/BadgeMember.java
@@ -14,6 +14,9 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(
+    uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "badge_id"})
+)
 public class BadgeMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
@@ -103,6 +103,14 @@ public class Member {
         this.representativeBadge = memberBadge;
     }
 
+    /**
+     * Member 삭제 시(memberBadges cascade remove) FK 순환으로 인한 삭제 실패를 방지합니다.
+     */
+    @PreRemove
+    private void preRemove() {
+        this.representativeBadge = null;
+    }
+
 
     public void updateNickname(String nickName) {
         this.nickName = nickName;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/entity/Member.java
@@ -1,14 +1,7 @@
 package site.beilsang.beilsang_server_v2.domain.member.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -85,6 +78,31 @@ public class Member {
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChallengeLike> challengeLikes = new ArrayList<>();
+
+
+    /** 멤버가 보유한 모든 배지 목록 */
+    @Builder.Default
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BadgeMember> memberBadges = new ArrayList<>();
+
+    // 대표 배지
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "representative_badge_id")
+    private BadgeMember representativeBadge;
+
+// ── 비즈니스 메서드 추가 ─────────────────────────────────────────────────
+
+    /**
+     * 대표 배지 설정 — 4단계 배지만 허용, null로 해제도 가능
+     */
+    public void updateRepresentativeBadge(BadgeMember memberBadge) {
+        if (memberBadge != null && !memberBadge.isEligibleForRepresentative()) {
+            throw new IllegalArgumentException("4단계(숲) 배지만 대표 배지로 설정할 수 있습니다.");
+        }
+        this.representativeBadge = memberBadge;
+    }
+
 
     public void updateNickname(String nickName) {
         this.nickName = nickName;

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/BadgeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/BadgeMemberRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import site.beilsang.beilsang_server_v2.domain.member.entity.BadgeMember;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
 import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,4 +33,6 @@ public interface BadgeMemberRepository extends JpaRepository<BadgeMember, Long> 
         @Param("member") Member member,
         @Param("badgeType") BadgeType badgeType
     );
+
+    Optional<BadgeMember>  findByMemberIdAndBadgeCategory(Long memberId, Category category);
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/BadgeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/BadgeMemberRepository.java
@@ -1,0 +1,31 @@
+package site.beilsang.beilsang_server_v2.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import site.beilsang.beilsang_server_v2.domain.member.entity.BadgeMember;
+import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
+import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BadgeMemberRepository extends JpaRepository<BadgeMember, Long> {
+    /**
+     * 멤버의 전체 보유 배지 목록 조회
+     * Badge 정보를 fetch join으로 함께 로딩 (N+1 방지)
+     */
+    @Query("SELECT mb FROM BadgeMember mb JOIN FETCH mb.badge WHERE mb.member.id = :memberId")
+    List<BadgeMember> findAllByMemberIdWithBadge(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 MemberBadge 단건 조회 (본인 소유 여부 확인 포함)
+     */
+    @Query("SELECT mb FROM BadgeMember mb JOIN FETCH mb.badge WHERE mb.id = :memberBadgeId AND mb.member.id = :memberId")
+    Optional<BadgeMember> findByIdAndMemberId(
+        @Param("memberBadgeId") Long memberBadgeId,
+        @Param("memberId") Long memberId
+    );
+
+    Boolean existsByMemberAndChallengeBadgeType(Member member, ChallengeBadgeType badgeType);
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/BadgeMemberRepository.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/domain/member/repository/BadgeMemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.beilsang.beilsang_server_v2.domain.member.entity.BadgeMember;
 import site.beilsang.beilsang_server_v2.domain.member.entity.Member;
-import site.beilsang.beilsang_server_v2.global.enums.ChallengeBadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,5 +27,9 @@ public interface BadgeMemberRepository extends JpaRepository<BadgeMember, Long> 
         @Param("memberId") Long memberId
     );
 
-    Boolean existsByMemberAndChallengeBadgeType(Member member, ChallengeBadgeType badgeType);
+    @Query("SELECT COUNT(mb) > 0 FROM BadgeMember mb WHERE mb.member = :member AND mb.badge.badgeType = :badgeType")
+    Boolean existsByMemberAndBadge_BadgeType(
+        @Param("member") Member member,
+        @Param("badgeType") BadgeType badgeType
+    );
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/common/exception/BaseResponseCode.java
@@ -52,7 +52,13 @@ public enum BaseResponseCode {
     NOT_LIKED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0008", "찜하지 않은 챌린지입니다"),
     NOT_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "C0009", "참여하지 않은 챌린지입니다"),
     CHALLENGE_NOT_ENDED(HttpStatus.BAD_REQUEST, "C0010", "완료되지 않은 챌린지입니다"),
-    CHALLENGE_NOT_STARTED(HttpStatus.BAD_REQUEST, "C0011", "아직 시작하지 않은 챌린지입니다");
+    CHALLENGE_NOT_STARTED(HttpStatus.BAD_REQUEST, "C0011", "아직 시작하지 않은 챌린지입니다"),
+
+    //badge
+    NOT_FOUND_MEMBER_BADGE(HttpStatus.BAD_REQUEST, "B0001", "보유하지 않은 배지입니다"),
+    NOT_ELIGIBLE_BADGE(HttpStatus.BAD_REQUEST, "B0002", "4단계 배지가 아닙니다"),
+    NOT_FOUND_BADGE(HttpStatus.BAD_REQUEST, "B0003", "존재하지 않는 배지입니다"),
+    ;
 
     private final HttpStatus status; // 커스텀 상태코드
     private final String code; // Http 상태코드

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/BadgeDataInitializer.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/BadgeDataInitializer.java
@@ -1,0 +1,52 @@
+package site.beilsang.beilsang_server_v2.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import site.beilsang.beilsang_server_v2.domain.badge.entity.Badge;
+import site.beilsang.beilsang_server_v2.domain.badge.repository.BadgeRepository;
+import site.beilsang.beilsang_server_v2.global.enums.BadgeType;
+import site.beilsang.beilsang_server_v2.global.enums.Category;
+
+@Component
+@RequiredArgsConstructor
+public class BadgeDataInitializer implements ApplicationRunner {
+
+    private final BadgeRepository badgeRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+
+        if (badgeRepository.count() > 0) {
+            // 배지가 이미 존재하면 초기화 작업을 건너뜁니다.
+            return;
+        }
+
+        // 1. 활동 배지 초기화 (CHALLENGE_START, CREATE, VERIFY)
+        for (BadgeType badgeType : BadgeType.values()) {
+            // 카테고리용 BadgeType(예: CATEGORY)이 Enum에 있다면 제외하고 처리
+            if (badgeType.name().equals("CATEGORY")) continue;
+
+            if (!badgeRepository.existsByBadgeType(badgeType)) {
+                badgeRepository.save(Badge.builder()
+                    .badgeType(badgeType)
+                    .category(null) // 활동 배지는 카테고리가 없음
+                    .build());
+            }
+        }
+
+        // 2. 카테고리 배지 9종 초기화
+        // Category Enum(예: 건강, 운동, 공부 등 9개)을 순회하며 생성
+        for (Category category : Category.values()) {
+            if (!badgeRepository.existsByCategory(category)) {
+                badgeRepository.save(Badge.builder()
+                    .badgeType(BadgeType.CATEGORY) // 타입을 CATEGORY로 통일 (Enum에 CATEGORY 추가 필요)
+                    .category(category)            // 각각의 카테고리 할당
+                    .build());
+            }
+        }
+    }
+}

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/config/BadgeDataInitializer.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/config/BadgeDataInitializer.java
@@ -20,15 +20,10 @@ public class BadgeDataInitializer implements ApplicationRunner {
     @Transactional
     public void run(ApplicationArguments args) {
 
-        if (badgeRepository.count() > 0) {
-            // 배지가 이미 존재하면 초기화 작업을 건너뜁니다.
-            return;
-        }
-
         // 1. 활동 배지 초기화 (CHALLENGE_START, CREATE, VERIFY)
         for (BadgeType badgeType : BadgeType.values()) {
             // 카테고리용 BadgeType(예: CATEGORY)이 Enum에 있다면 제외하고 처리
-            if (badgeType.name().equals("CATEGORY")) continue;
+            if (badgeType == BadgeType.CATEGORY) continue;
 
             if (!badgeRepository.existsByBadgeType(badgeType)) {
                 badgeRepository.save(Badge.builder()

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/BadgeType.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/BadgeType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum ChallengeBadgeType {
+public enum BadgeType {
 
     /**
      * 활동 배지 (3종) - 단계 없음

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/BadgeType.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/BadgeType.java
@@ -13,4 +13,9 @@ public enum BadgeType {
     CHALLENGE_START,    // 챌린지 1개 참여
     CHALLENGE_CREATE,   // 챌린지 1개 제작
     CHALLENGE_VERIFY,   // 챌린지 인증 피드 1개 인증
+
+    /**
+     * 카테고리 배지
+     */
+    CATEGORY,
 }

--- a/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeBadgeType.java
+++ b/src/main/java/site/beilsang/beilsang_server_v2/global/enums/ChallengeBadgeType.java
@@ -1,0 +1,16 @@
+package site.beilsang.beilsang_server_v2.global.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ChallengeBadgeType {
+
+    /**
+     * 활동 배지 (3종) - 단계 없음
+     */
+    CHALLENGE_START,    // 챌린지 1개 참여
+    CHALLENGE_CREATE,   // 챌린지 1개 제작
+    CHALLENGE_VERIFY,   // 챌린지 인증 피드 1개 인증
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #79 

## 🍬 기능 설명
사용자의 동기부여를 위한 뱃지 시스템(활동 배지 3종 및 카테고리 배지 9종)을 신설하고, 챌린지 성공 시 데이터가 누적되는 정산 시스템을 연동했습니다.

- **배지 도감 및 소유 구조 설계**: 
  - 원본 배지 데이터를 관리하는 `Badge` 테이블과 사용자의 획득 상태를 관리하는 `BadgeMember` 테이블로 분리 설계했습니다.
- **활동 배지 3종 자동 부여**: 
  - 챌린지 제작(`CHALLENGE_CREATE`), 시작(`CHALLENGE_START`), 인증(`CHALLENGE_VERIFY`) 시 최초 1회에 한해 배지가 자동 부여됩니다.
- **카테고리 배지 9종 성장 로직**: 
  - 챌린지 종료 및 정산 시 성공한 유저들의 카테고리별 성공 횟수(`count`)를 누적합니다.
  - 별도의 단계 컬럼을 DB에 저장하지 않고, `count` 기반으로 단계(1단계 새싹 ~ 4단계 숲)를 동적으로 계산(`getStep()`)하도록 아키텍처를 최적화했습니다.
- **효율적인 마스터 데이터 초기화**: 
  - `BadgeDataInitializer`를 통해 서버 구동 시 배지 마스터 데이터가 자동 세팅되도록 구현했으며, 불필요한 DB 조회를 방지하기 위해 `LIMIT 1` 방식으로 존재 여부를 사전 체크하도록 최적화했습니다.
- **대표 배지 설정/해제 API**:
  - 4단계(숲)에 도달한 카테고리 배지만 대표 배지로 설정할 수 있도록 예외 검증 로직을 포함했습니다.

## 🤔 코드 리뷰에서 집중적으로 볼 내용

1. **`BadgeMember.java` 의 동적 단계 계산 로직 (`getStep()`)**
   - DB 용량 아끼고 데이터 불일치를 막으려고 `count` 필드 하나만 저장하고, 단계(1~4)는 메서드로 동적 계산하게 처리했습니다. 기획(0/1/3/10개 성공 시 1/2/3/4단계)대로 예외 없이 잘 작동하는지 봐주세요!
2. **미획득 배지 미반환 처리 (프론트엔드와 역할 분담)**
   - 사용자가 한 번도 성공하지 않은 카테고리는 `BadgeMember` 데이터를 굳이 생성하지 않고 API 응답에서도 제외했습니다. 프론트엔드에서 응답에 없는 카테고리를 기본값(1단계 새싹)으로 처리하기로 합의했는데, 이 방식이 비즈니스 요구사항에 문제없을지 확인 부탁드립니다.
3. **`Badge` 엔티티 다중 컬럼 유니크 제약조건**
   - 카테고리 배지들은 `BadgeType.CATEGORY`를 공유하므로 단일 유니크를 걸 수 없었습니다. 중복 데이터 방지를 위해 `(badge_type, category)` 복합 유니크 제약조건을 `@Table`에 걸어두었는데 올바르게 적용되었는지 체크 부탁드립니다.

## ⭐ 기타 사항
- `BadgeDataInitializer` 실행 시 `count()` 대신 `findFirstBy().isPresent()`를 사용하여 데이터 존재 여부를 검증합니다. (DB 테이블 풀 스캔을 방지하고 `LIMIT 1`로 성능을 최적화하기 위함)
- 챌린지 정산 서비스(`ChallengeSettlementService`)에서 포인트 분배 직전에 배지 카운트 누적 로직을 트랜잭션 내에서 안전하게 처리하도록 결합했습니다.