### PR TITLE
[Fix] 서버 타임존 KST 고정으로 시간 불일치 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ FROM eclipse-temurin:17-jdk-alpine
 
 WORKDIR /app
 
+# 타임존 설정 (KST)
+RUN apk add --no-cache tzdata
+ENV TZ=Asia/Seoul
+
 # 애플리케이션 실행을 위한 사용자 생성 (보안)
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,7 @@ services:
       - DB_URL=${DB_URL}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
+      - TZ=Asia/Seoul
     volumes:
       - ./logs:/app/logs
     networks:

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -24,6 +24,7 @@ services:
       - DB_URL=${DB_URL}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
+      - TZ=Asia/Seoul
     volumes:
       - ./logs:/app/logs
     networks:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
   config:
     import:
       - classpath:nickname.yml
+  jackson:
+    time-zone: Asia/Seoul # 타임존 KST 고정 (JSON 직렬화 시 KST 기준)
   servlet:
     multipart:
       max-file-size: 3MB # 파일당 최대 크기


### PR DESCRIPTION
## 📌 이슈 번호
<!-- closed #번호 -->
- #110 

## 🍬 기능 설명

서버(컨테이너)가 기본 타임존인 UTC로 동작하면서 발생한 시간 불일치 문제를 해결한다.

- `Dockerfile` 실행 스테이지에 tzdata 설치 및 `TZ=Asia/Seoul` 설정
- `docker-compose.prod.yml`, `docker-compose.stage.yml` environment에 `TZ=Asia/Seoul` 추가
- `application.yml`에 `spring.jackson.time-zone: Asia/Seoul` 추가

**수정 전 발생하던 문제**
- KST 새벽 0~9시에 "오늘 시작" 챌린지 생성 시 서버의 UTC `LocalDate.now()`가 "어제"를 반환하여 `NOT_YET`으로 잘못 분류됨
- 스케줄러 cron 자정이 실제로는 KST 오전 9시에 실행되어 상태 전환·포인트 정산이 9시간 지연됨
- 로컬(KST)과 운영(UTC)에서 생성된 타임스탬프 값이 DB에 혼재

## 🤔 코드 리뷰에서 집중적으로 볼 내용

- `Dockerfile`에서 `tzdata` 설치를 `USER appuser` 전에 수행하는 위치 — root 권한이 필요하므로 사용자 전환 전에 위치해야 함
- `TZ` 환경변수를 Dockerfile(`ENV`)과 docker-compose 양쪽에 모두 설정한 이유 — Dockerfile의 `ENV`는 이미지 레벨 기본값, docker-compose의 `environment`는 컨테이너 실행 시 덮어쓰는 방식으로 이중 보장

## ⭐ 기타 사항

- JWT/Apple 토큰 만료(`Instant`/`new Date()`)는 절대 시점 기반이라 타임존과 무관하여 수정 대상에서 제외
- `startDate`/`finishDate`는 `LocalDate`(달력 날짜)로 클라이언트가 받은 그대로 사용하므로 변환 대상 아님
- 관련 개념 정리: `docs/TIMEZONE_CONCEPTS.md`